### PR TITLE
feat(auth): add password reset

### DIFF
--- a/apps/web/src/app/(site)/forgot-password/page.tsx
+++ b/apps/web/src/app/(site)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Reset your password" };
+
+export { ForgotPasswordPage as default } from "@/features/auth/pages/forgot-password-page";

--- a/apps/web/src/app/(site)/reset-password/page.tsx
+++ b/apps/web/src/app/(site)/reset-password/page.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Choose a new password" };
+
+export const instant = false;
+
+export { ResetPasswordPage as default } from "@/features/auth/pages/reset-password-page";

--- a/apps/web/src/features/auth/components/forgot-password-card.tsx
+++ b/apps/web/src/features/auth/components/forgot-password-card.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { MailCheck } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -58,17 +59,25 @@ export function ForgotPasswordCard() {
   if (isSent) {
     return (
       <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Check your inbox</CardTitle>
+        <CardHeader className="items-center text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <MailCheck className="size-5 text-primary" aria-hidden="true" />
+            Check your inbox
+          </CardTitle>
           <CardDescription>
             If that email belongs to a Tsuki account, we sent a password-reset link.
           </CardDescription>
         </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
+        <CardContent className="text-center text-sm text-muted-foreground">
           The link expires in 30 minutes. Check spam if it does not arrive soon.
         </CardContent>
-        <CardFooter>
-          <Button className="w-full" variant="link" render={<Link href="/login" replace />}>
+        <CardFooter className="flex-col gap-2">
+          <Button
+            className="w-full"
+            variant="link"
+            render={<Link href="/login" replace />}
+            nativeButton={false}
+          >
             Back to sign in
           </Button>
         </CardFooter>

--- a/apps/web/src/features/auth/components/forgot-password-card.tsx
+++ b/apps/web/src/features/auth/components/forgot-password-card.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { authClient } from "@tsuki/auth/client";
+import { env } from "@tsuki/env/web";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+import { forgotPasswordSchema, type ForgotPasswordValues } from "../schemas";
+import { AuthFormCard } from "./auth-form-card";
+
+const FORM_ID = "forgot-password-form";
+
+export function ForgotPasswordCard() {
+  const [isSent, setIsSent] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  async function submit({ email }: ForgotPasswordValues) {
+    try {
+      const { error } = await authClient.requestPasswordReset({
+        email,
+        redirectTo: `${env.NEXT_PUBLIC_APP_URL}/reset-password`,
+      });
+
+      if (error) {
+        toast.error(error.message || "Unable to send the reset email.");
+        return;
+      }
+
+      setIsSent(true);
+    } catch {
+      toast.error("Unable to reach the server. Try again.");
+    }
+  }
+
+  if (isSent) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Check your inbox</CardTitle>
+          <CardDescription>
+            If that email belongs to a Tsuki account, we sent a password-reset link.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          The link expires in 30 minutes. Check spam if it does not arrive soon.
+        </CardContent>
+        <CardFooter>
+          <Button className="w-full" variant="link" render={<Link href="/login" replace />}>
+            Back to sign in
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <AuthFormCard
+      title="Reset your password"
+      description="Enter your email and we will send a reset link."
+      alternateHref="/login"
+      alternateLabel="Sign in"
+      formId={FORM_ID}
+      isSubmitting={isSubmitting}
+      onSubmit={handleSubmit(submit)}
+      submitLabel="Send reset link"
+    >
+      <FieldGroup>
+        <Field data-invalid={Boolean(errors.email)}>
+          <FieldLabel htmlFor="forgot-password-email">Email</FieldLabel>
+          <Input
+            id="forgot-password-email"
+            type="email"
+            autoComplete="email"
+            {...register("email")}
+            aria-invalid={Boolean(errors.email)}
+            disabled={isSubmitting}
+          />
+          <FieldError errors={errors.email ? [errors.email] : []} />
+        </Field>
+      </FieldGroup>
+    </AuthFormCard>
+  );
+}

--- a/apps/web/src/features/auth/components/login-card.tsx
+++ b/apps/web/src/features/auth/components/login-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -81,6 +82,12 @@ export function LoginCard() {
           />
           <FieldError errors={errors.password ? [errors.password] : []} />
         </Field>
+        <Link
+          href="/forgot-password"
+          className="text-sm text-primary underline-offset-4 hover:underline"
+        >
+          Forgot password?
+        </Link>
       </FieldGroup>
     </AuthFormCard>
   );

--- a/apps/web/src/features/auth/components/reset-password-card.tsx
+++ b/apps/web/src/features/auth/components/reset-password-card.tsx
@@ -26,11 +26,7 @@ import { AuthFormCard } from "./auth-form-card";
 
 const FORM_ID = "reset-password-form";
 
-type ResetPasswordCardProps = {
-  token?: string;
-};
-
-export function ResetPasswordCard({ token }: ResetPasswordCardProps) {
+export function ResetPasswordCard({ token }: { token?: string }) {
   const [isComplete, setIsComplete] = useState(false);
   const {
     register,
@@ -42,9 +38,7 @@ export function ResetPasswordCard({ token }: ResetPasswordCardProps) {
   });
 
   async function submit({ password }: ResetPasswordValues) {
-    if (!token) {
-      return;
-    }
+    if (!token) return;
 
     try {
       const { error: resetError } = await authClient.resetPassword({

--- a/apps/web/src/features/auth/components/reset-password-card.tsx
+++ b/apps/web/src/features/auth/components/reset-password-card.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Link from "next/link";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { authClient } from "@tsuki/auth/client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+import { resetPasswordSchema, type ResetPasswordValues } from "../schemas";
+import { AuthFormCard } from "./auth-form-card";
+
+const FORM_ID = "reset-password-form";
+
+type ResetPasswordCardProps = {
+  token?: string;
+};
+
+export function ResetPasswordCard({ token }: ResetPasswordCardProps) {
+  const [isComplete, setIsComplete] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ResetPasswordValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function submit({ password }: ResetPasswordValues) {
+    if (!token) {
+      return;
+    }
+
+    try {
+      const { error: resetError } = await authClient.resetPassword({
+        newPassword: password,
+        token,
+      });
+
+      if (resetError) {
+        toast.error(resetError.message || "Unable to reset your password.");
+        return;
+      }
+
+      setIsComplete(true);
+    } catch {
+      toast.error("Unable to reach the server. Try again.");
+    }
+  }
+
+  if (!token) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Reset link unavailable</CardTitle>
+          <CardDescription>This reset link is invalid or has expired.</CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Button className="w-full" render={<Link href="/forgot-password" replace />}>
+            Request a new link
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  if (isComplete) {
+    return (
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Password updated</CardTitle>
+          <CardDescription>
+            Your password has been reset and your sessions were signed out.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          You can now sign in with your new password.
+        </CardContent>
+        <CardFooter>
+          <Button className="w-full" render={<Link href="/login" replace />}>
+            Sign in
+          </Button>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <AuthFormCard
+      title="Choose a new password"
+      description="Use at least 8 characters."
+      alternateHref="/login"
+      alternateLabel="Sign in"
+      formId={FORM_ID}
+      isSubmitting={isSubmitting}
+      onSubmit={handleSubmit(submit)}
+      submitLabel="Reset password"
+    >
+      <FieldGroup>
+        <Field data-invalid={Boolean(errors.password)}>
+          <FieldLabel htmlFor="new-password">New password</FieldLabel>
+          <Input
+            id="new-password"
+            type="password"
+            autoComplete="new-password"
+            {...register("password")}
+            aria-invalid={Boolean(errors.password)}
+            disabled={isSubmitting}
+          />
+          <FieldError errors={errors.password ? [errors.password] : []} />
+        </Field>
+        <Field data-invalid={Boolean(errors.confirmPassword)}>
+          <FieldLabel htmlFor="confirm-password">Confirm new password</FieldLabel>
+          <Input
+            id="confirm-password"
+            type="password"
+            autoComplete="new-password"
+            {...register("confirmPassword")}
+            aria-invalid={Boolean(errors.confirmPassword)}
+            disabled={isSubmitting}
+          />
+          <FieldError errors={errors.confirmPassword ? [errors.confirmPassword] : []} />
+        </Field>
+      </FieldGroup>
+    </AuthFormCard>
+  );
+}

--- a/apps/web/src/features/auth/components/reset-password-card.tsx
+++ b/apps/web/src/features/auth/components/reset-password-card.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { CircleCheck, KeyRound } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -65,12 +66,19 @@ export function ResetPasswordCard({ token }: ResetPasswordCardProps) {
   if (!token) {
     return (
       <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Reset link unavailable</CardTitle>
+        <CardHeader className="items-center text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <KeyRound className="size-5 text-primary" aria-hidden="true" />
+            Reset link unavailable
+          </CardTitle>
           <CardDescription>This reset link is invalid or has expired.</CardDescription>
         </CardHeader>
-        <CardFooter>
-          <Button className="w-full" render={<Link href="/forgot-password" replace />}>
+        <CardFooter className="flex-col gap-2">
+          <Button
+            className="w-full"
+            render={<Link href="/forgot-password" replace />}
+            nativeButton={false}
+          >
             Request a new link
           </Button>
         </CardFooter>
@@ -81,17 +89,20 @@ export function ResetPasswordCard({ token }: ResetPasswordCardProps) {
   if (isComplete) {
     return (
       <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Password updated</CardTitle>
+        <CardHeader className="items-center text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <CircleCheck className="size-5 text-primary" aria-hidden="true" />
+            Password updated
+          </CardTitle>
           <CardDescription>
             Your password has been reset and your sessions were signed out.
           </CardDescription>
         </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
+        <CardContent className="text-center text-sm text-muted-foreground">
           You can now sign in with your new password.
         </CardContent>
-        <CardFooter>
-          <Button className="w-full" render={<Link href="/login" replace />}>
+        <CardFooter className="flex-col gap-2">
+          <Button className="w-full" render={<Link href="/login" replace />} nativeButton={false}>
             Sign in
           </Button>
         </CardFooter>

--- a/apps/web/src/features/auth/components/verify-email-card.tsx
+++ b/apps/web/src/features/auth/components/verify-email-card.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 import { authClient } from "@tsuki/auth/client";
+import { env } from "@tsuki/env/web";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -28,7 +29,7 @@ export function VerifyEmailCard({ email }: { email?: string }) {
     try {
       const { error } = await authClient.sendVerificationEmail({
         email,
-        callbackURL: window.location.origin,
+        callbackURL: env.NEXT_PUBLIC_APP_URL,
       });
 
       if (error) {

--- a/apps/web/src/features/auth/components/verify-email-card.tsx
+++ b/apps/web/src/features/auth/components/verify-email-card.tsx
@@ -77,7 +77,12 @@ export function VerifyEmailCard({ email }: { email?: string }) {
             Resend verification email
           </Button>
         )}
-        <Button className="w-full" variant="link" render={<Link href="/login" replace />}>
+        <Button
+          className="w-full"
+          variant="link"
+          render={<Link href="/login" replace />}
+          nativeButton={false}
+        >
           Back to sign in
         </Button>
       </CardFooter>

--- a/apps/web/src/features/auth/pages/forgot-password-page.tsx
+++ b/apps/web/src/features/auth/pages/forgot-password-page.tsx
@@ -1,0 +1,9 @@
+import { ForgotPasswordCard } from "../components/forgot-password-card";
+
+export function ForgotPasswordPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <ForgotPasswordCard />
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/pages/reset-password-page.tsx
+++ b/apps/web/src/features/auth/pages/reset-password-page.tsx
@@ -1,0 +1,15 @@
+import { ResetPasswordCard } from "../components/reset-password-card";
+
+type ResetPasswordPageProps = {
+  searchParams: Promise<{ token?: string }>;
+};
+
+export async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+  const { token } = await searchParams;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <ResetPasswordCard token={token} />
+    </div>
+  );
+}

--- a/apps/web/src/features/auth/pages/reset-password-page.tsx
+++ b/apps/web/src/features/auth/pages/reset-password-page.tsx
@@ -1,10 +1,10 @@
 import { ResetPasswordCard } from "../components/reset-password-card";
 
-type ResetPasswordPageProps = {
+export async function ResetPasswordPage({
+  searchParams,
+}: {
   searchParams: Promise<{ token?: string }>;
-};
-
-export async function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+}) {
   const { token } = await searchParams;
 
   return (

--- a/apps/web/src/features/auth/schemas.ts
+++ b/apps/web/src/features/auth/schemas.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 import { usernameSchema } from "@/shared/lib/username";
 
+const passwordSchema = z.string().min(8, "Password must be at least 8 characters");
+
 export const loginSchema = z.object({
   emailOrUsername: z.string().trim().min(1, "Email or username is required"),
   password: z.string().min(1, "Password is required"),
@@ -11,8 +13,24 @@ export const signUpSchema = z.object({
   name: z.string().trim().min(2, "Name must be at least 2 characters"),
   username: usernameSchema,
   email: z.email("Enter a valid email address"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
+  password: passwordSchema,
 });
 
+export const forgotPasswordSchema = z.object({
+  email: z.email("Enter a valid email address"),
+});
+
+export const resetPasswordSchema = z
+  .object({
+    password: passwordSchema,
+    confirmPassword: z.string().min(1, "Confirm your password"),
+  })
+  .refine(({ password, confirmPassword }) => password === confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ForgotPasswordValues = z.infer<typeof forgotPasswordSchema>;
 export type LoginValues = z.infer<typeof loginSchema>;
+export type ResetPasswordValues = z.infer<typeof resetPasswordSchema>;
 export type SignUpValues = z.infer<typeof signUpSchema>;

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,3 +1,5 @@
+import { env } from "@tsuki/env/email";
+
 const HTML_ENTITIES: Record<string, string> = {
   "&": "&amp;",
   "<": "&lt;",
@@ -55,7 +57,6 @@ function createEmailContent({
 }
 
 export async function sendEmail({ actionLabel, actionUrl, description, subject, to }: Email) {
-  const { env } = await import("@tsuki/env/email");
   const content = createEmailContent({ actionLabel, actionUrl, description });
   // Comment out the development condition to send emails to their real recipient locally.
   const recipient = process.env.NODE_ENV === "development" ? "delivered+local-dev@resend.dev" : to;

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,12 +1,63 @@
 import { env } from "@tsuki/env/email";
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#039;",
+};
+
 type Email = {
+  actionLabel: string;
+  actionUrl: string;
+  description: string;
   subject: string;
-  text: string;
   to: string;
 };
 
-export async function sendEmail({ subject, text, to }: Email) {
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (character) => HTML_ENTITIES[character]);
+}
+
+function createEmailContent({
+  actionLabel,
+  actionUrl,
+  description,
+}: Omit<Email, "subject" | "to">) {
+  const safeActionLabel = escapeHtml(actionLabel);
+  const safeActionUrl = escapeHtml(actionUrl);
+  const safeDescription = escapeHtml(description);
+
+  return {
+    html: `<!doctype html>
+<html lang="en">
+  <body style="margin:0;background:#eef5e6;color:#44624a;font-family:Arial,sans-serif">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="padding:40px 16px">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:520px;background:#ffffff;border:1px solid #d3dcc3;border-radius:10px">
+            <tr>
+              <td style="padding:32px">
+                <p style="margin:0 0 24px;font-size:20px;font-weight:700;letter-spacing:-0.3px">Tsuki</p>
+                <h1 style="margin:0 0 12px;font-size:24px;line-height:1.25;color:#44624a">${safeActionLabel}</h1>
+                <p style="margin:0 0 28px;font-size:16px;line-height:1.6;color:#5d735f">${safeDescription}</p>
+                <a href="${safeActionUrl}" style="display:inline-block;border-radius:6px;background:#7b9756;padding:12px 18px;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none">${safeActionLabel}</a>
+                <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#8b9e82">If you did not request this, you can safely ignore this email.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`,
+    text: `${description}\n\n${actionLabel}: ${actionUrl}\n\nIf you did not request this, you can safely ignore this email.`,
+  };
+}
+
+export async function sendEmail({ actionLabel, actionUrl, description, subject, to }: Email) {
+  const content = createEmailContent({ actionLabel, actionUrl, description });
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -16,8 +67,8 @@ export async function sendEmail({ subject, text, to }: Email) {
     },
     body: JSON.stringify({
       from: env.RESEND_FROM_EMAIL,
+      ...content,
       subject,
-      text,
       to: [to],
     }),
   });

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -1,5 +1,3 @@
-import { env } from "@tsuki/env/email";
-
 const HTML_ENTITIES: Record<string, string> = {
   "&": "&amp;",
   "<": "&lt;",
@@ -57,7 +55,11 @@ function createEmailContent({
 }
 
 export async function sendEmail({ actionLabel, actionUrl, description, subject, to }: Email) {
+  const { env } = await import("@tsuki/env/email");
   const content = createEmailContent({ actionLabel, actionUrl, description });
+  // Comment out the development condition to send emails to their real recipient locally.
+  const recipient = process.env.NODE_ENV === "development" ? "delivered+local-dev@resend.dev" : to;
+
   const response = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -69,7 +71,7 @@ export async function sendEmail({ actionLabel, actionUrl, description, subject, 
       from: env.RESEND_FROM_EMAIL,
       ...content,
       subject,
-      to: [to],
+      to: [recipient],
     }),
   });
 

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -32,18 +32,18 @@ function createEmailContent({
   return {
     html: `<!doctype html>
 <html lang="en">
-  <body style="margin:0;background:#eef5e6;color:#44624a;font-family:Arial,sans-serif">
+  <body style="margin:0;background:#0a0a0a;color:#171717;font-family:Arial,sans-serif">
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="padding:40px 16px">
       <tr>
         <td align="center">
-          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:520px;background:#ffffff;border:1px solid #d3dcc3;border-radius:10px">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:520px;background:#ffffff;border-radius:8px">
             <tr>
               <td style="padding:32px">
-                <p style="margin:0 0 24px;font-size:20px;font-weight:700;letter-spacing:-0.3px">Tsuki</p>
-                <h1 style="margin:0 0 12px;font-size:24px;line-height:1.25;color:#44624a">${safeActionLabel}</h1>
-                <p style="margin:0 0 28px;font-size:16px;line-height:1.6;color:#5d735f">${safeDescription}</p>
-                <a href="${safeActionUrl}" style="display:inline-block;border-radius:6px;background:#7b9756;padding:12px 18px;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none">${safeActionLabel}</a>
-                <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#8b9e82">If you did not request this, you can safely ignore this email.</p>
+                <p style="margin:0 0 24px;font-size:20px;font-weight:700;letter-spacing:-0.3px;color:#171717">Tsuki</p>
+                <h1 style="margin:0 0 12px;font-size:24px;line-height:1.25;color:#171717">${safeActionLabel}</h1>
+                <p style="margin:0 0 28px;font-size:16px;line-height:1.6;color:#525252">${safeDescription}</p>
+                <a href="${safeActionUrl}" style="display:inline-block;border-radius:6px;background:#171717;padding:12px 18px;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none">${safeActionLabel}</a>
+                <p style="margin:28px 0 0;font-size:13px;line-height:1.6;color:#737373">If you did not request this, you can safely ignore this email.</p>
               </td>
             </tr>
           </table>

--- a/packages/auth/src/email.ts
+++ b/packages/auth/src/email.ts
@@ -15,7 +15,7 @@ type Email = {
 };
 
 function escapeHtml(value: string) {
-  return value.replace(/[&<>"']/g, (character) => HTML_ENTITIES[character]);
+  return value.replace(/[&<>"']/g, (character) => HTML_ENTITIES[character]!);
 }
 
 function createEmailContent({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -14,6 +14,16 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: true,
+    resetPasswordTokenExpiresIn: 60 * 30,
+    revokeSessionsOnPasswordReset: true,
+    sendResetPassword: async ({ user, url }) => {
+      const { sendEmail } = await import("./email");
+      await sendEmail({
+        to: user.email,
+        subject: "Reset your Tsuki password",
+        text: `Reset your password:\n\n${url}`,
+      });
+    },
   },
   emailVerification: {
     autoSignInAfterVerification: true,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -41,6 +41,15 @@ export const auth = betterAuth({
       });
     },
   },
+  rateLimit: {
+    customRules: {
+      "/request-password-reset": { max: 1, window: 60 },
+      "/send-verification-email": { max: 1, window: 60 },
+      "/sign-up/email": { max: 1, window: 60 },
+    },
+    enabled: true,
+    storage: "database",
+  },
   plugins: [
     username(),
     haveIBeenPwned({

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -19,9 +19,11 @@ export const auth = betterAuth({
     sendResetPassword: async ({ user, url }) => {
       const { sendEmail } = await import("./email");
       await sendEmail({
+        actionLabel: "Reset password",
+        actionUrl: url,
+        description: "We received a request to reset your Tsuki password.",
         to: user.email,
         subject: "Reset your Tsuki password",
-        text: `Reset your password:\n\n${url}`,
       });
     },
   },
@@ -31,9 +33,11 @@ export const auth = betterAuth({
     sendVerificationEmail: async ({ user, url }) => {
       const { sendEmail } = await import("./email");
       await sendEmail({
+        actionLabel: "Verify email",
+        actionUrl: url,
+        description: "Confirm your email to finish setting up your Tsuki account.",
         to: user.email,
         subject: "Verify your Tsuki email",
-        text: `Verify your email to start using Tsuki:\n\n${url}`,
       });
     },
   },

--- a/packages/db/src/schema/tables/auth.ts
+++ b/packages/db/src/schema/tables/auth.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, boolean, index } from "drizzle-orm/pg-core";
+import { bigint, boolean, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -80,3 +80,10 @@ export const verification = pgTable(
   },
   (table) => [index("verification_identifier_idx").on(table.identifier)],
 );
+
+export const rateLimit = pgTable("rate_limit", {
+  id: text("id").primaryKey(),
+  key: text("key").notNull().unique(),
+  count: integer("count").notNull(),
+  lastRequest: bigint("last_request", { mode: "number" }).notNull(),
+});


### PR DESCRIPTION
## Summary
- add Better Auth password-reset email delivery with 30-minute links
- revoke sessions after a successful reset
- add forgot-password and reset-password screens
- Rate limiting in our database for better auth