### PR TITLE
fix: close mobile navigation dropdown after selecting login

### DIFF
--- a/apps/web/src/features/navigation/components/navigation-auth.tsx
+++ b/apps/web/src/features/navigation/components/navigation-auth.tsx
@@ -13,9 +13,11 @@ import { cn } from "@/shared/lib/utils";
 export function NavigationAuth({
   isAuthenticated,
   isMobile = false,
+  onNavigate,
 }: {
   isAuthenticated: boolean;
   isMobile?: boolean;
+  onNavigate?: () => void;
 }) {
   const [isSigningOut, setIsSigningOut] = useState(false);
   const pathname = usePathname();
@@ -24,6 +26,7 @@ export function NavigationAuth({
     return (
       <Link
         href="/login"
+        onNavigate={onNavigate}
         className={cn(
           isMobile
             ? "flex w-full items-center rounded-lg px-3 py-3 text-xs font-black uppercase tracking-widest transition-all duration-300"

--- a/apps/web/src/features/navigation/components/site-navigation.tsx
+++ b/apps/web/src/features/navigation/components/site-navigation.tsx
@@ -96,7 +96,11 @@ export function SiteNavigation({ user }: { user: NavigationUser | null }) {
             />
             <div className="my-2 h-px w-full bg-border" />
             <div className="flex items-center justify-between px-1">
-              <NavigationAuth isAuthenticated={Boolean(user?.username)} isMobile />
+              <NavigationAuth
+                isAuthenticated={Boolean(user?.username)}
+                isMobile
+                onNavigate={closeMobileMenu}
+              />
               <div className="pr-2">
                 <ThemeToggle />
               </div>


### PR DESCRIPTION
## Changes
- Close the mobile menu when the Login link completes client-side navigation.
- Reuse the existing navigation close callback used by other mobile links.

## Verification
- `bun run typecheck`
- `bunx oxfmt --check apps/web/src/features/navigation/components/navigation-auth.tsx apps/web/src/features/navigation/components/site-navigation.tsx`
- `bun test` (fails on pre-existing `mediaImageClass` expectation mismatch: expected `grayscale contrast-125`, received `grayscale opacity-90`)
- Independent code review: no findings