### PR TITLE
fix: clarify and deduplicate manga external links

### DIFF
--- a/apps/api/src/modules/media/index.ts
+++ b/apps/api/src/modules/media/index.ts
@@ -15,7 +15,7 @@ import { MediaCompactModel, MediaModel, MediaTypeEnum, type MediaType } from "./
  */
 export async function ensureMedia(type: MediaType, id: number) {
   const cached = await mediaDal.getMediaById(type, id);
-  if (cached) return cached;
+  if (cached && !cached.externalLinks?.some((link) => !("language" in link))) return cached;
 
   const fetched = await anilistMediaById(type, id);
   if (!fetched) return null;

--- a/apps/api/src/modules/media/index.ts
+++ b/apps/api/src/modules/media/index.ts
@@ -15,6 +15,7 @@ import { MediaCompactModel, MediaModel, MediaTypeEnum, type MediaType } from "./
  */
 export async function ensureMedia(type: MediaType, id: number) {
   const cached = await mediaDal.getMediaById(type, id);
+  // TODO: Remove after all cached external links have been backfilled with language metadata.
   if (cached && !cached.externalLinks?.some((link) => !("language" in link))) return cached;
 
   const fetched = await anilistMediaById(type, id);

--- a/apps/api/src/modules/media/model.ts
+++ b/apps/api/src/modules/media/model.ts
@@ -115,6 +115,7 @@ export const MediaModel = t.Composite([
           url: t.String(),
           site: t.String(),
           type: t.String(),
+          language: t.Optional(t.Nullable(t.String())),
           color: t.Nullable(t.String()),
           icon: t.Nullable(t.String()),
         }),

--- a/apps/web/src/features/media/components/media-details.tsx
+++ b/apps/web/src/features/media/components/media-details.tsx
@@ -4,7 +4,7 @@ import type { Media } from "@tsuki/api/types";
 
 import { Badge } from "@/components/ui/badge";
 
-import { mediaDescriptionText, unitCount } from "../media";
+import { formatExternalLinks, mediaDescriptionText, unitCount } from "../media";
 import { MediaActions } from "./media-actions";
 import { MediaTrailer } from "./media-trailer";
 
@@ -66,7 +66,7 @@ export function MediaDetails({ media }: { media: Media }) {
                     />
                   ) : null}
                   <span className="group-hover:underline group-hover:decoration-dashed group-hover:underline-offset-4">
-                    {link.site}
+                    {link.label}
                   </span>
                   <ExternalLink className="size-3 opacity-0 transition-opacity group-hover:opacity-100" />
                 </a>
@@ -120,10 +120,11 @@ function getDetailItems(media: Media) {
 
 function getMediaLinks(media: Media) {
   return {
-    heading: media.type === "ANIME" ? "Where to Watch" : "More Info",
-    items:
+    heading: media.type === "ANIME" ? "Where to Watch" : "Where to Read",
+    items: formatExternalLinks(
       media.type === "ANIME"
         ? (media.externalLinks?.filter((link) => link.type === "STREAMING") ?? [])
         : (media.externalLinks ?? []),
+    ),
   };
 }

--- a/apps/web/src/features/media/media.test.ts
+++ b/apps/web/src/features/media/media.test.ts
@@ -46,7 +46,7 @@ describe("mediaDescriptionText", () => {
 describe("mediaImageClass", () => {
   test("uses monochrome styling only for manga", () => {
     expect(mediaImageClass("ANIME")).toBeUndefined();
-    expect(mediaImageClass("MANGA")).toBe("grayscale contrast-125");
+    expect(mediaImageClass("MANGA")).toBe("grayscale opacity-90");
   });
 });
 
@@ -57,6 +57,7 @@ describe("formatExternalLinks", () => {
         { url: "https://webtoons.com/en", site: "WEBTOON", language: "English" },
         { url: "https://webtoons.com/fr", site: "WEBTOON", language: "French" },
         { url: "https://webtoons.com/en", site: "WEBTOON", language: "English" },
+        { url: "https://webtoons.com/legacy", site: "WEBTOON" },
         { url: "https://naver.com", site: "Naver Webtoon", language: "Korean" },
         { url: "https://legacy.example", site: "Legacy", language: null },
       ]),
@@ -72,6 +73,11 @@ describe("formatExternalLinks", () => {
         site: "WEBTOON",
         language: "French",
         label: "WEBTOON (French)",
+      },
+      {
+        url: "https://webtoons.com/legacy",
+        site: "WEBTOON",
+        label: "WEBTOON",
       },
       {
         url: "https://naver.com",

--- a/apps/web/src/features/media/media.test.ts
+++ b/apps/web/src/features/media/media.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { mediaDescriptionText, mediaImageClass, parseMediaId } from "./media";
+import { formatExternalLinks, mediaDescriptionText, mediaImageClass, parseMediaId } from "./media";
 import { mediaIdSchema } from "./schemas";
 
 describe("parseMediaId", () => {
@@ -47,5 +47,44 @@ describe("mediaImageClass", () => {
   test("uses monochrome styling only for manga", () => {
     expect(mediaImageClass("ANIME")).toBeUndefined();
     expect(mediaImageClass("MANGA")).toBe("grayscale contrast-125");
+  });
+});
+
+describe("formatExternalLinks", () => {
+  test("deduplicates URLs and disambiguates repeated sites by language", () => {
+    expect(
+      formatExternalLinks([
+        { url: "https://webtoons.com/en", site: "WEBTOON", language: "English" },
+        { url: "https://webtoons.com/fr", site: "WEBTOON", language: "French" },
+        { url: "https://webtoons.com/en", site: "WEBTOON", language: "English" },
+        { url: "https://naver.com", site: "Naver Webtoon", language: "Korean" },
+        { url: "https://legacy.example", site: "Legacy", language: null },
+      ]),
+    ).toEqual([
+      {
+        url: "https://webtoons.com/en",
+        site: "WEBTOON",
+        language: "English",
+        label: "WEBTOON (English)",
+      },
+      {
+        url: "https://webtoons.com/fr",
+        site: "WEBTOON",
+        language: "French",
+        label: "WEBTOON (French)",
+      },
+      {
+        url: "https://naver.com",
+        site: "Naver Webtoon",
+        language: "Korean",
+        label: "Naver Webtoon",
+      },
+      {
+        url: "https://legacy.example",
+        site: "Legacy",
+        language: null,
+        label: "Legacy",
+      },
+    ]);
   });
 });

--- a/apps/web/src/features/media/media.ts
+++ b/apps/web/src/features/media/media.ts
@@ -78,6 +78,27 @@ export function mediaImageClass(mediaType: MediaType) {
   return mediaType === "MANGA" ? "grayscale opacity-90" : undefined;
 }
 
+type ExternalLink = {
+  url: string;
+  site: string;
+  language?: string | null;
+};
+
+export function formatExternalLinks<T extends ExternalLink>(links: T[]): (T & { label: string })[] {
+  const uniqueLinks = links.filter(
+    (link, index) => links.findIndex(({ url }) => url === link.url) === index,
+  );
+  const siteCounts = Map.groupBy(uniqueLinks, ({ site }) => site);
+
+  return uniqueLinks.map((link) => ({
+    ...link,
+    label:
+      siteCounts.get(link.site)!.length > 1 && link.language
+        ? `${link.site} (${link.language})`
+        : link.site,
+  }));
+}
+
 export function getMediaTitle(media: {
   titleEnglish?: string | null;
   titleRomaji?: string | null;

--- a/apps/web/src/features/media/media.ts
+++ b/apps/web/src/features/media/media.ts
@@ -88,12 +88,15 @@ export function formatExternalLinks<T extends ExternalLink>(links: T[]): (T & { 
   const uniqueLinks = links.filter(
     (link, index) => links.findIndex(({ url }) => url === link.url) === index,
   );
-  const siteCounts = Map.groupBy(uniqueLinks, ({ site }) => site);
+  const siteCounts = new Map<string, number>();
+  for (const { site } of uniqueLinks) {
+    siteCounts.set(site, (siteCounts.get(site) ?? 0) + 1);
+  }
 
   return uniqueLinks.map((link) => ({
     ...link,
     label:
-      siteCounts.get(link.site)!.length > 1 && link.language
+      siteCounts.get(link.site)! > 1 && link.language
         ? `${link.site} (${link.language})`
         : link.site,
   }));

--- a/packages/anilist/src/queries/fragments.ts
+++ b/packages/anilist/src/queries/fragments.ts
@@ -63,6 +63,7 @@ export const MEDIA_FIELDS = gql`
       url
       site
       type
+      language
       color
       icon
     }

--- a/packages/anilist/src/types.ts
+++ b/packages/anilist/src/types.ts
@@ -69,6 +69,7 @@ type MediaExternalLink = {
   url: string;
   site: string;
   type: string;
+  language: string | null;
   color: string | null;
   icon: string | null;
 };

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -18,6 +18,8 @@ export type MediaExternalLink = {
   url: string;
   site: string;
   type: string;
+  /** Optional for links cached before AniList's language metadata was stored. */
+  language?: string | null;
   color: string | null;
   icon: string | null;
 };


### PR DESCRIPTION
Clarifies manga external links as reading destinations and labels localized duplicates while preserving each URL.