### PR TITLE
refactor: streamline media detail metadata

### DIFF
--- a/apps/api/src/modules/media/model.ts
+++ b/apps/api/src/modules/media/model.ts
@@ -56,16 +56,6 @@ export const MediaSourceEnum = t.Union([
   t.Literal("PICTURE_BOOK"),
 ]);
 
-const MediaTagModel = t.Object({
-  id: t.Number(),
-  name: t.String(),
-  category: t.Nullable(t.String()),
-  rank: t.Nullable(t.Number()),
-  isGeneralSpoiler: t.Boolean(),
-  isMediaSpoiler: t.Boolean(),
-  isAdult: t.Boolean(),
-});
-
 /** The shape embedded in cards, grids, library entries and reviews. */
 export const MediaCompactModel = t.Object({
   id: t.Number(),
@@ -89,10 +79,7 @@ export const MediaCompactModel = t.Object({
 export const MediaModel = t.Composite([
   MediaCompactModel,
   t.Object({
-    idMal: t.Nullable(t.Number()),
-    synonyms: t.Nullable(t.Array(t.String())),
     description: t.Nullable(t.String()),
-    coverImageMedium: t.Nullable(t.String()),
     status: t.Nullable(MediaStatusEnum),
     source: t.Nullable(MediaSourceEnum),
     countryOfOrigin: t.Nullable(t.String()),
@@ -103,11 +90,9 @@ export const MediaModel = t.Composite([
     startDate: t.Nullable(FuzzyDateModel),
     endDate: t.Nullable(FuzzyDateModel),
     season: t.Nullable(MediaSeasonEnum),
-    meanScore: t.Nullable(t.Number()),
     popularity: t.Nullable(t.Number()),
     favourites: t.Nullable(t.Number()),
     genres: t.Nullable(t.Array(t.String())),
-    tags: t.Nullable(t.Array(MediaTagModel)),
     trailer: t.Nullable(t.Object({ id: t.String(), site: t.String(), thumbnail: t.String() })),
     externalLinks: t.Nullable(
       t.Array(
@@ -121,8 +106,6 @@ export const MediaModel = t.Composite([
         }),
       ),
     ),
-    siteUrl: t.Nullable(t.String()),
-    isAdult: t.Nullable(t.Boolean()),
   }),
 ]);
 

--- a/apps/web/src/features/media/components/media-details.tsx
+++ b/apps/web/src/features/media/components/media-details.tsx
@@ -4,7 +4,14 @@ import type { Media } from "@tsuki/api/types";
 
 import { Badge } from "@/components/ui/badge";
 
-import { formatExternalLinks, mediaDescriptionText, unitCount } from "../media";
+import {
+  formatCountry,
+  formatExternalLinks,
+  formatFuzzyDate,
+  formatMediaSource,
+  mediaDescriptionText,
+  unitCount,
+} from "../media";
 import { MediaActions } from "./media-actions";
 import { MediaTrailer } from "./media-trailer";
 
@@ -35,11 +42,11 @@ export function MediaDetails({ media }: { media: Media }) {
           <h3 className="text-sm font-semibold tracking-wider text-muted-foreground uppercase">
             Details
           </h3>
-          <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-1">
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm md:grid-cols-1">
             {detailItems.map((item) => (
               <InfoItem key={item.label} label={item.label} value={item.value} />
             ))}
-          </div>
+          </dl>
         </div>
 
         {links.items.length > 0 ? (
@@ -96,9 +103,9 @@ export function MediaDetails({ media }: { media: Media }) {
 function InfoItem({ label, value }: { label: string; value: React.ReactNode }) {
   if (value == null || value === "") return null;
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-muted-foreground">{label}</span>
-      <span className="font-medium text-foreground">{value}</span>
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium text-foreground">{value}</dd>
     </div>
   );
 }
@@ -115,7 +122,21 @@ function getDetailItems(media: Media) {
           { label: "Volumes", value: media.volumes },
         ];
 
-  return [...typeSpecificItems, { label: "Popularity", value: media.popularity?.toLocaleString() }];
+  return [
+    ...typeSpecificItems,
+    { label: "Start date", value: formatFuzzyDate(media.startDate) },
+    { label: "End date", value: formatFuzzyDate(media.endDate) },
+    { label: "Source", value: media.source ? formatMediaSource(media.source) : null },
+    { label: "Country", value: formatCountry(media.countryOfOrigin) },
+    {
+      label: "AniList popularity",
+      value: media.popularity?.toLocaleString("en-US"),
+    },
+    {
+      label: "AniList favourites",
+      value: media.favourites?.toLocaleString("en-US"),
+    },
+  ];
 }
 
 function getMediaLinks(media: Media) {

--- a/apps/web/src/features/media/media.test.ts
+++ b/apps/web/src/features/media/media.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatExternalLinks, mediaDescriptionText, mediaImageClass, parseMediaId } from "./media";
+import {
+  formatCountry,
+  formatExternalLinks,
+  formatFuzzyDate,
+  formatMediaSource,
+  mediaDescriptionText,
+  mediaImageClass,
+  parseMediaId,
+} from "./media";
 import { mediaIdSchema } from "./schemas";
 
 describe("parseMediaId", () => {
@@ -92,5 +100,26 @@ describe("formatExternalLinks", () => {
         label: "Legacy",
       },
     ]);
+  });
+});
+
+describe("media metadata formatting", () => {
+  test("formats every useful fuzzy date precision without inventing missing parts", () => {
+    expect(formatFuzzyDate({ year: 2024, month: 5, day: 12 })).toBe("May 12, 2024");
+    expect(formatFuzzyDate({ year: 2024, month: 5, day: null })).toBe("May 2024");
+    expect(formatFuzzyDate({ year: 2024, month: null, day: null })).toBe("2024");
+    expect(formatFuzzyDate({ year: null, month: 5, day: 12 })).toBe("May 12");
+    expect(formatFuzzyDate({ year: null, month: 5, day: null })).toBe("May");
+    expect(formatFuzzyDate({ year: 2024, month: null, day: 12 })).toBe("Day 12, 2024");
+    expect(formatFuzzyDate({ year: null, month: null, day: 12 })).toBe("Day 12");
+    expect(formatFuzzyDate({ year: null, month: null, day: null })).toBeNull();
+    expect(formatFuzzyDate(null)).toBeNull();
+  });
+
+  test("makes AniList enum and country values readable", () => {
+    expect(formatMediaSource("LIGHT_NOVEL")).toBe("Light novel");
+    expect(formatCountry("JP")).toBe("Japan");
+    expect(formatCountry(null)).toBeNull();
+    expect(formatCountry("not-a-country")).toBeNull();
   });
 });

--- a/apps/web/src/features/media/media.ts
+++ b/apps/web/src/features/media/media.ts
@@ -52,6 +52,9 @@ export const MEDIA = {
 export const MEDIA_TYPES = ["ANIME", "MANGA"] as const satisfies readonly MediaType[];
 export const MAX_MEDIA_ID = 2_147_483_647;
 
+const MONTH_FORMATTER = new Intl.DateTimeFormat("en", { month: "long", timeZone: "UTC" });
+const REGION_NAMES = new Intl.DisplayNames(["en"], { type: "region" });
+
 /**
  * The API stores one status vocabulary for both types, so CURRENT has to render
  * as "Watching" or "Reading" depending on what is being displayed.
@@ -134,6 +137,43 @@ export function parseMediaId(value: string) {
 
 export function formatMediaStatus(value: string) {
   return value.toLowerCase().replaceAll("_", " ");
+}
+
+export function formatMediaSource(value: string) {
+  const label = formatMediaStatus(value);
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+export function formatCountry(code: string | null) {
+  if (!code) return null;
+
+  const normalizedCode = code.toUpperCase();
+  try {
+    const name = REGION_NAMES.of(normalizedCode);
+    return name === normalizedCode ? null : name;
+  } catch {
+    return null;
+  }
+}
+
+export function formatFuzzyDate(
+  date: { year: number | null; month: number | null; day: number | null } | null,
+) {
+  if (!date) return null;
+
+  const year = date.year?.toString();
+  const month = date.month
+    ? MONTH_FORMATTER.format(new Date(Date.UTC(2000, date.month - 1)))
+    : null;
+  const day = date.day;
+
+  if (month && day && year) return `${month} ${day}, ${year}`;
+  if (month && day) return `${month} ${day}`;
+  if (month && year) return `${month} ${year}`;
+  if (month) return month;
+  if (day && year) return `Day ${day}, ${year}`;
+  if (day) return `Day ${day}`;
+  return year ?? null;
 }
 
 const NAMED_ENTITIES: Record<string, string> = {

--- a/packages/anilist/src/api/mappers.test.ts
+++ b/packages/anilist/src/api/mappers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AnilistMedia } from "../types";
+
+import { toMediaRow } from "./mappers";
+
+const media = {
+  id: 21,
+  type: "ANIME",
+  title: { romaji: "One Piece", english: "One Piece", native: "ONE PIECE" },
+  description: "Pirates",
+  coverImage: { extraLarge: null, large: null, color: null },
+  bannerImage: null,
+  format: "TV",
+  status: "RELEASING",
+  source: "MANGA",
+  countryOfOrigin: "JP",
+  episodes: null,
+  duration: 24,
+  chapters: null,
+  volumes: null,
+  startDate: { year: 1999, month: 10, day: null },
+  endDate: { year: null, month: null, day: null },
+  season: "FALL",
+  seasonYear: 1999,
+  averageScore: 88,
+  popularity: 800_000,
+  favourites: 50_000,
+  genres: ["Adventure", null],
+  trailer: null,
+  externalLinks: [null],
+} satisfies AnilistMedia;
+
+describe("toMediaRow", () => {
+  test("preserves partial dates and normalizes empty AniList values", () => {
+    expect(toMediaRow(media)).toMatchObject({
+      startDate: { year: 1999, month: 10, day: null },
+      endDate: null,
+      genres: ["Adventure"],
+      externalLinks: null,
+    });
+  });
+});

--- a/packages/anilist/src/api/mappers.ts
+++ b/packages/anilist/src/api/mappers.ts
@@ -19,16 +19,13 @@ function normalizeDate(date: FuzzyDate | null | undefined): FuzzyDate | null {
 export function toMediaRow(media: AnilistMedia) {
   return {
     id: media.id,
-    idMal: media.idMal,
     type: media.type,
     titleRomaji: media.title.romaji,
     titleEnglish: media.title.english,
     titleNative: media.title.native,
-    synonyms: dropNulls(media.synonyms),
     description: media.description,
     coverImageExtraLarge: media.coverImage.extraLarge,
     coverImageLarge: media.coverImage.large,
-    coverImageMedium: media.coverImage.medium,
     coverImageColor: media.coverImage.color,
     bannerImage: media.bannerImage,
     format: media.format,
@@ -44,15 +41,11 @@ export function toMediaRow(media: AnilistMedia) {
     season: media.season,
     seasonYear: media.seasonYear,
     averageScore: media.averageScore,
-    meanScore: media.meanScore,
     popularity: media.popularity,
     favourites: media.favourites,
     genres: dropNulls(media.genres),
-    tags: dropNulls(media.tags),
     trailer: media.trailer,
     externalLinks: dropNulls(media.externalLinks),
-    siteUrl: media.siteUrl,
-    isAdult: media.isAdult ?? false,
   };
 }
 

--- a/packages/anilist/src/queries/fragments.ts
+++ b/packages/anilist/src/queries/fragments.ts
@@ -4,19 +4,16 @@ import { gql } from "graphql-request";
 export const MEDIA_FIELDS = gql`
   fragment MediaFields on Media {
     id
-    idMal
     type
     title {
       romaji
       english
       native
     }
-    synonyms
     description
     coverImage {
       extraLarge
       large
-      medium
       color
     }
     bannerImage
@@ -41,19 +38,9 @@ export const MEDIA_FIELDS = gql`
     season
     seasonYear
     averageScore
-    meanScore
     popularity
     favourites
     genres
-    tags {
-      id
-      name
-      category
-      rank
-      isGeneralSpoiler
-      isMediaSpoiler
-      isAdult
-    }
     trailer {
       id
       site
@@ -67,8 +54,6 @@ export const MEDIA_FIELDS = gql`
       color
       icon
     }
-    siteUrl
-    isAdult
   }
 `;
 

--- a/packages/anilist/src/types.ts
+++ b/packages/anilist/src/types.ts
@@ -55,7 +55,6 @@ type MediaTitle = {
 type MediaCoverImage = {
   extraLarge: string | null;
   large: string | null;
-  medium: string | null;
   color: string | null;
 };
 
@@ -74,23 +73,11 @@ type MediaExternalLink = {
   icon: string | null;
 };
 
-type MediaTag = {
-  id: number;
-  name: string;
-  category: string | null;
-  rank: number | null;
-  isGeneralSpoiler: boolean;
-  isMediaSpoiler: boolean;
-  isAdult: boolean;
-};
-
 /** The full `Media` selection — see MEDIA_FIELDS in ./queries/fragments. */
 export type AnilistMedia = {
   id: number;
-  idMal: number | null;
   type: MediaType;
   title: MediaTitle;
-  synonyms: (string | null)[] | null;
   description: string | null;
   coverImage: MediaCoverImage;
   bannerImage: string | null;
@@ -111,15 +98,11 @@ export type AnilistMedia = {
   season: MediaSeason | null;
   seasonYear: number | null;
   averageScore: number | null;
-  meanScore: number | null;
   popularity: number | null;
   favourites: number | null;
   genres: (string | null)[] | null;
-  tags: (MediaTag | null)[] | null;
   trailer: MediaTrailer | null;
   externalLinks: (MediaExternalLink | null)[] | null;
-  siteUrl: string | null;
-  isAdult: boolean | null;
 };
 
 /** The trimmed selection — mirrors MEDIA_COMPACT_FIELDS in ./queries/fragments. */

--- a/packages/anilist/tsconfig.json
+++ b/packages/anilist/tsconfig.json
@@ -5,5 +5,6 @@
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,
     "types": ["node"]
-  }
+  },
+  "exclude": ["**/*.test.ts"]
 }

--- a/packages/db/src/schema/tables/library.ts
+++ b/packages/db/src/schema/tables/library.ts
@@ -34,8 +34,7 @@ export const libraryEntries = pgTable(
     status: listStatusEnum("status"),
     /**
      * 1–10, enforced by `library_entries_score_range` below. Null means unscored.
-     * Not the same scale as `media.averageScore` / `media.meanScore`, which come
-     * from AniList as 0–100.
+     * Not the same scale as `media.averageScore`, which comes from AniList as 0–100.
      */
     score: integer("score"),
     /**

--- a/packages/db/src/schema/tables/media.ts
+++ b/packages/db/src/schema/tables/media.ts
@@ -1,15 +1,6 @@
-import {
-  pgTable,
-  text,
-  timestamp,
-  boolean,
-  integer,
-  jsonb,
-  index,
-  unique,
-} from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, integer, jsonb, index, unique } from "drizzle-orm/pg-core";
 
-import type { FuzzyDate, MediaExternalLink, MediaTag, MediaTrailer } from "../types";
+import type { FuzzyDate, MediaExternalLink, MediaTrailer } from "../types";
 import {
   mediaFormatEnum,
   mediaSeasonEnum,
@@ -22,16 +13,13 @@ export const media = pgTable(
   "media",
   {
     id: integer("id").primaryKey(), // AniList id
-    idMal: integer("id_mal"),
     type: mediaTypeEnum("type").notNull(),
     titleRomaji: text("title_romaji"),
     titleEnglish: text("title_english"),
     titleNative: text("title_native"),
-    synonyms: jsonb("synonyms").$type<string[]>(),
     description: text("description"),
     coverImageExtraLarge: text("cover_image_extra_large"),
     coverImageLarge: text("cover_image_large"),
-    coverImageMedium: text("cover_image_medium"),
     coverImageColor: text("cover_image_color"),
     bannerImage: text("banner_image"),
     format: mediaFormatEnum("format"),
@@ -51,15 +39,11 @@ export const media = pgTable(
     season: mediaSeasonEnum("season"),
     seasonYear: integer("season_year"),
     averageScore: integer("average_score"),
-    meanScore: integer("mean_score"),
     popularity: integer("popularity"),
     favourites: integer("favourites"),
     genres: jsonb("genres").$type<string[]>(),
-    tags: jsonb("tags").$type<MediaTag[]>(),
     trailer: jsonb("trailer").$type<MediaTrailer>(),
     externalLinks: jsonb("external_links").$type<MediaExternalLink[]>(),
-    siteUrl: text("site_url"),
-    isAdult: boolean("is_adult").default(false),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at")
       .defaultNow()

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -23,13 +23,3 @@ export type MediaExternalLink = {
   color: string | null;
   icon: string | null;
 };
-
-export type MediaTag = {
-  id: number;
-  name: string;
-  category: string | null;
-  rank: number | null;
-  isGeneralSpoiler: boolean;
-  isMediaSpoiler: boolean;
-  isAdult: boolean;
-};


### PR DESCRIPTION
Displays readable AniList dates, source, country, popularity, and favourite counts on anime and manga detail pages. Removes unused full-detail fields across the AniList, database, API, and web layers.