### PR TITLE
fix(web): restore media page ui regressions

### DIFF
--- a/apps/web/src/features/media/components/media-header.tsx
+++ b/apps/web/src/features/media/components/media-header.tsx
@@ -42,7 +42,7 @@ export function MediaHeader({
       </Badge>
     ),
     statusLabel && (
-      <Badge key="status" variant="outline">
+      <Badge key="status" variant="outline" className="uppercase">
         {statusLabel}
       </Badge>
     ),

--- a/apps/web/src/shared/components/external-link.tsx
+++ b/apps/web/src/shared/components/external-link.tsx
@@ -6,10 +6,15 @@ export function ExternalLink({ href, children }: { href: string; children: React
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:underline hover:underline-offset-4"
+      className="group inline-flex w-fit items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
     >
-      {children}
-      <ExternalLinkIcon aria-hidden="true" className="size-3" />
+      <span className="group-hover:underline group-hover:decoration-dashed group-hover:underline-offset-4">
+        {children}
+      </span>
+      <ExternalLinkIcon
+        aria-hidden="true"
+        className="size-3 opacity-0 transition-opacity group-hover:opacity-100"
+      />
     </a>
   );
 }


### PR DESCRIPTION
## Summary

- Restore uppercase rendering for anime media statuses
- Restore media external-link hover styling and icon behavior

## Validation

- oxlint passed via pre-commit hook
- oxfmt passed via pre-commit hook
- `git diff --check` passed
- Typecheck/lint scripts were unavailable before commit because local dependencies were incomplete