### PR TITLE
feat(api): add openapi docs via @elysiajs/openapi

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "dev": "bun run --watch src/index.ts"
   },
   "dependencies": {
+    "@elysiajs/openapi": "^1.4.15",
     "@tsuki/anilist": "workspace:*",
     "@tsuki/auth": "workspace:*",
     "@tsuki/db": "workspace:*",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,4 +1,5 @@
 import { Elysia } from "elysia";
+import { openapi } from "@elysiajs/openapi";
 
 import { authPlugin } from "./plugins/auth";
 import { errorsPlugin } from "./plugins/errors";
@@ -11,6 +12,17 @@ import { reviewRoutes } from "./modules/reviews";
 import { socialRoutes } from "./modules/social";
 
 export const app = new Elysia()
+  .use(
+    openapi({
+      documentation: {
+        info: {
+          title: "Tsuki API",
+          description: "Anime tracking platform API",
+          version: "1.0.50",
+        },
+      },
+    }),
+  )
   .use(errorsPlugin)
   .use(loggerPlugin)
   .use(authPlugin)

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,12 +14,22 @@ import { socialRoutes } from "./modules/social";
 export const app = new Elysia()
   .use(
     openapi({
+      path: "/docs",
       documentation: {
         info: {
           title: "Tsuki API",
           description: "Anime tracking platform API",
           version: "1.0.50",
         },
+        tags: [
+          { name: "Media", description: "Anime & manga from AniList" },
+          { name: "Library", description: "Personal watch/read lists" },
+          { name: "Reviews", description: "Scored reviews" },
+          { name: "Social", description: "Follows and discovery" },
+          { name: "Activity", description: "Activity feed" },
+          { name: "Profiles", description: "User profiles" },
+          { name: "Auth", description: "Better Auth endpoints (mounted)" },
+        ],
       },
     }),
   )

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -30,6 +30,15 @@ export const app = new Elysia()
           { name: "Profiles", description: "User profiles" },
           { name: "Auth", description: "Better Auth endpoints (mounted)" },
         ],
+        components: {
+          securitySchemes: {
+            sessionCookie: {
+              type: "apiKey",
+              in: "cookie",
+              name: "better-auth.session_token",
+            },
+          },
+        },
       },
     }),
   )

--- a/apps/api/src/modules/activity/index.ts
+++ b/apps/api/src/modules/activity/index.ts
@@ -4,7 +4,7 @@ import { authPlugin } from "../../plugins/auth";
 import { getActivityFeed } from "./service";
 import { FeedModel, FeedQueryModel } from "./model";
 
-export const activityRoutes = new Elysia()
+export const activityRoutes = new Elysia({ tags: ["Activity"] })
   .use(authPlugin)
   .get("/me/activity", ({ query, user }) => getActivityFeed(user.id, query.type, query), {
     auth: true,

--- a/apps/api/src/modules/library/index.ts
+++ b/apps/api/src/modules/library/index.ts
@@ -10,7 +10,7 @@ import { ReviewModel } from "../reviews/model";
 import { LibraryEntryInputModel, LibraryEntryModel, LibraryQueryModel } from "./model";
 import { logMedia, removeEntry } from "./service";
 
-export const libraryRoutes = new Elysia()
+export const libraryRoutes = new Elysia({ tags: ["Library"] })
   .use(authPlugin)
   .get(
     "/users/:username/library",

--- a/apps/api/src/modules/media/index.ts
+++ b/apps/api/src/modules/media/index.ts
@@ -7,7 +7,7 @@ import { ErrorModel } from "../../plugins/errors";
 import { ensureMedia } from "./service";
 import { MediaCompactModel, MediaModel, MediaTypeEnum } from "./model";
 
-export const mediaRoutes = new Elysia({ prefix: "/media" })
+export const mediaRoutes = new Elysia({ prefix: "/media", tags: ["Media"] })
   .get(
     "/:type/trending",
     async ({ params: { type } }) => {

--- a/apps/api/src/modules/profiles/index.ts
+++ b/apps/api/src/modules/profiles/index.ts
@@ -12,7 +12,7 @@ import { ProfileModel, UpdateProfileModel, UserOverviewModel } from "./model";
 // app's Eden clients are updated alongside. Routes kept as-is for now to
 // avoid a breaking change.
 
-export const profilesRoutes = new Elysia()
+export const profilesRoutes = new Elysia({ tags: ["Profiles"] })
   .use(authPlugin)
   .get(
     "/users/:username",

--- a/apps/api/src/modules/reviews/index.ts
+++ b/apps/api/src/modules/reviews/index.ts
@@ -9,7 +9,7 @@ import { requireUser } from "../profiles/service";
 import { ReviewInputModel, ReviewModel, ReviewQueryModel } from "./model";
 import { removeReview, submitReview } from "./service";
 
-export const reviewRoutes = new Elysia()
+export const reviewRoutes = new Elysia({ tags: ["Reviews"] })
   .use(authPlugin)
   .get(
     "/users/:username/reviews",

--- a/apps/api/src/modules/social/index.ts
+++ b/apps/api/src/modules/social/index.ts
@@ -17,7 +17,7 @@ import { followProfile, unfollowProfile } from "./service";
 /** Popular on Tsuki: the default Friends list size. */
 const DISCOVERY_LIMIT = 24;
 
-export const socialRoutes = new Elysia()
+export const socialRoutes = new Elysia({ tags: ["Social"] })
   .use(authPlugin)
   .get(
     "/users/discover",

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -8,6 +8,7 @@ export const authPlugin = new Elysia({ name: "better-auth" }).mount(auth.handler
     // Declared here so every `auth: true` route carries a typed 401, rather than
     // each one repeating it in its own response map.
     response: { 401: ErrorModel },
+    detail: { security: [{ sessionCookie: [] }] },
     async resolve({ request: { headers } }) {
       const session = await auth.api.getSession({ headers });
 


### PR DESCRIPTION
- Integrates `@elysiajs/openapi` — interactive docs at `/docs`, spec at `/docs/json`, auto-generated from existing route schemas
- Groups endpoints by module tags (Media, Library, Reviews, Social, Activity, Profiles)
- Marks all `auth: true` routes with a session-cookie security scheme via the auth macro