### PR TITLE
fix(web): make home page prerender instead of dynamic

### DIFF
--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,7 +1,5 @@
 import { Suspense } from "react";
 
-import { io } from "next/cache";
-
 import { getDiscoverMediaTrending } from "@/features/discover/data";
 import { DiscoverView } from "@/features/discover/views/discover-view";
 import { ContentState } from "@/shared/components/content-state";
@@ -15,7 +13,6 @@ export default function Page() {
 }
 
 async function DiscoverContent() {
-  await io();
   const trending = await getDiscoverMediaTrending().catch(() => null);
 
   if (!trending) {

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -13,7 +13,7 @@ export default function Page() {
 }
 
 async function DiscoverContent() {
-  const trending = await getDiscoverMediaTrending().catch(() => null);
+  const trending = await getDiscoverMediaTrending();
 
   if (!trending) {
     return (

--- a/apps/web/src/features/discover/data.ts
+++ b/apps/web/src/features/discover/data.ts
@@ -8,10 +8,16 @@ import { publicApi } from "@/shared/lib/public-api";
 
 export async function getDiscoverMediaTrending() {
   "use cache: remote";
-  cacheLife("days");
 
-  const [anime, manga] = await Promise.all([getTrending("ANIME"), getTrending("MANGA")]);
-  return { ANIME: anime, MANGA: manga };
+  try {
+    const [anime, manga] = await Promise.all([getTrending("ANIME"), getTrending("MANGA")]);
+    cacheLife("days");
+    return { ANIME: anime, MANGA: manga };
+  } catch {
+    // ponytail: don't poison the cache on failure — retry on next request instead
+    cacheLife({ stale: 0, revalidate: 30, expire: 60 });
+    return null;
+  }
 }
 
 async function getTrending(mediaType: MediaType) {


### PR DESCRIPTION
- remove `await io()` from the discover page so it no longer opts into request-time rendering
- home route `/` now shows as partial prerender (static shell + cached trending data) instead of fully dynamic
- existing error fallback still handles anilist being unavailable at build time