### PR TITLE
feat(web): seo overhaul

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@tsuki/anilist": "workspace:*",
     "@tsuki/api": "workspace:*",
     "@tsuki/auth": "workspace:*",
+    "@tsuki/db": "workspace:*",
     "@tsuki/env": "workspace:*",
     "@tsuki/rich-content": "workspace:*",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/(app)/(auth)/layout.tsx
+++ b/apps/web/src/app/(app)/(auth)/layout.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+
 import { AuthLayout } from "@/features/auth/layouts/auth-layout";
+
+// Applies to every auth page: sign-in and account recovery never belong in an index.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return <AuthLayout>{children}</AuthLayout>;

--- a/apps/web/src/app/(app)/[username]/opengraph-image.tsx
+++ b/apps/web/src/app/(app)/[username]/opengraph-image.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from "next/og";
+
+import { richContentText } from "@tsuki/rich-content";
+
+import { getProfileOverview } from "@/features/profile/data";
+import { OgCard } from "@/shared/components/og-card";
+import { buildProfileOgCard } from "@/shared/lib/og-card";
+import { siteName } from "@/shared/lib/site";
+
+export const alt = "Profile card";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: Promise<{ username: string }> }) {
+  const profile = await getProfileOverview((await params).username);
+
+  if (!profile) {
+    return new ImageResponse(
+      <OgCard layout={buildProfileOgCard({ displayUsername: siteName, bio: null })} />,
+      size,
+    );
+  }
+
+  return new ImageResponse(
+    <OgCard
+      layout={buildProfileOgCard({
+        displayUsername: profile.user.displayUsername,
+        bio: richContentText(profile.profile?.bio).trim() || null,
+      })}
+    />,
+    size,
+  );
+}

--- a/apps/web/src/app/(app)/[username]/page.tsx
+++ b/apps/web/src/app/(app)/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { ProfileJsonLd } from "@/features/profile/components/profile-json-ld";
 import { resolveUsername } from "@/features/profile/data";
 import { ProfileOverviewView } from "@/features/profile/views/profile-overview-view";
 import { Loader } from "@/shared/components/loader";
@@ -9,6 +10,7 @@ export default async function Page({ params }: { params: Promise<{ username: str
 
   return (
     <Suspense fallback={<Loader />}>
+      <ProfileJsonLd username={username} />
       <ProfileOverviewView username={username} />
     </Suspense>
   );

--- a/apps/web/src/app/(app)/anime/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/(app)/anime/[id]/opengraph-image.tsx
@@ -1,0 +1,9 @@
+import { renderMediaOgImage, ogImageSize } from "@/features/media/og-image";
+
+export const alt = "Anime card";
+export const size = ogImageSize;
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: Promise<{ id: string }> }) {
+  return renderMediaOgImage("ANIME", (await params).id);
+}

--- a/apps/web/src/app/(app)/anime/[id]/page.tsx
+++ b/apps/web/src/app/(app)/anime/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { MediaJsonLd } from "@/features/media/components/media-json-ld";
 import { MediaPageSkeleton } from "@/features/media/components/media-skeletons";
 import { getMediaMetadata } from "@/features/media/data";
 import { MediaView } from "@/features/media/views/media-view";
@@ -15,6 +16,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   const { id } = await params;
   return (
     <Suspense fallback={<MediaPageSkeleton />}>
+      <MediaJsonLd mediaType="ANIME" id={id} />
       <MediaView mediaType="ANIME" id={id} />
     </Suspense>
   );

--- a/apps/web/src/app/(app)/manga/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/(app)/manga/[id]/opengraph-image.tsx
@@ -1,0 +1,9 @@
+import { renderMediaOgImage, ogImageSize } from "@/features/media/og-image";
+
+export const alt = "Manga card";
+export const size = ogImageSize;
+export const contentType = "image/png";
+
+export default async function Image({ params }: { params: Promise<{ id: string }> }) {
+  return renderMediaOgImage("MANGA", (await params).id);
+}

--- a/apps/web/src/app/(app)/manga/[id]/page.tsx
+++ b/apps/web/src/app/(app)/manga/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 
+import { MediaJsonLd } from "@/features/media/components/media-json-ld";
 import { MediaPageSkeleton } from "@/features/media/components/media-skeletons";
 import { getMediaMetadata } from "@/features/media/data";
 import { MediaView } from "@/features/media/views/media-view";
@@ -15,6 +16,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   const { id } = await params;
   return (
     <Suspense fallback={<MediaPageSkeleton />}>
+      <MediaJsonLd mediaType="MANGA" id={id} />
       <MediaView mediaType="MANGA" id={id} />
     </Suspense>
   );

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,8 +1,13 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { getDiscoverMediaTrending } from "@/features/discover/data";
 import { DiscoverView } from "@/features/discover/views/discover-view";
 import { ContentState } from "@/shared/components/content-state";
+
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
 
 export default function Page() {
   return (

--- a/apps/web/src/app/(app)/social/page.tsx
+++ b/apps/web/src/app/(app)/social/page.tsx
@@ -1,9 +1,15 @@
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 
 import { SocialView } from "@/features/social/views/social-view";
 import { getSession } from "@/shared/lib/session";
 
 export const instant = false;
+
+// Gated social area — members' activity never surfaces to strangers via search.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default async function Page() {
   const { user } = await getSession();

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -2,7 +2,10 @@ import type { Metadata } from "next";
 
 import { AdminLayout } from "@/features/admin/layouts/admin-layout";
 
-export const metadata: Metadata = { title: "Admin" };
+export const metadata: Metadata = {
+  title: "Admin",
+  robots: { index: false, follow: false },
+};
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return <AdminLayout>{children}</AdminLayout>;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,13 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import { AppProviders } from "@/shared/components/app-providers";
+import {
+  googleSiteVerification,
+  siteDescription,
+  siteName,
+  siteTagline,
+  siteUrl,
+} from "@/shared/lib/site";
 
 import "./globals.css";
 
@@ -17,11 +24,50 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: {
-    default: "Tsuki",
-    template: "%s | Tsuki",
+    default: siteTagline,
+    template: `%s | ${siteName}`,
   },
-  description: "Track, rate, and review anime and manga.",
+  description: siteDescription,
+  applicationName: siteName,
+  category: "entertainment",
+  appleWebApp: {
+    capable: true,
+    title: siteName,
+    statusBarStyle: "black-translucent",
+  },
+  formatDetection: {
+    telephone: false,
+  },
+  openGraph: {
+    type: "website",
+    siteName,
+    url: "/",
+    title: siteTagline,
+    description: siteDescription,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteTagline,
+    description: siteDescription,
+  },
+  ...(googleSiteVerification ? { verification: { google: googleSiteVerification } } : {}),
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: siteName,
+  url: siteUrl,
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${siteUrl}/?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
 };
 
 export default function RootLayout({
@@ -34,6 +80,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased`}
       >
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
         <AppProviders>{children}</AppProviders>
       </body>
     </html>

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+import { siteDescription, siteName, siteTagline } from "@/shared/lib/site";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: siteTagline,
+    short_name: siteName,
+    description: siteDescription,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0a0a0a",
+    theme_color: "#0a0a0a",
+    icons: [{ src: "/icon.png", sizes: "500x500", type: "image/png" }],
+  };
+}

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { ImageResponse } from "next/og";
+
+import { OgCard } from "@/shared/components/og-card";
+import { buildMinimalOgCard } from "@/shared/lib/og-card";
+import { siteDescription, siteTagline } from "@/shared/lib/site";
+
+export const alt = siteTagline;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(<OgCard layout={buildMinimalOgCard("Tsuki", siteDescription)} />, size);
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+
+import { siteUrl } from "@/shared/lib/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/admin",
+          "/api",
+          "/social",
+          "/login",
+          "/verify-email",
+          "/reset-password",
+          "/forgot-password",
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -10,7 +10,7 @@ import { buildSitemapEntries } from "@/shared/lib/sitemap";
 /** Cached so crawlers don't hit Postgres on every fetch; tags let re-syncs bust it. */
 async function getSitemapData() {
   "use cache: remote";
-  cacheLife("max");
+  cacheLife("days");
   cacheTag("media", "profiles");
 
   const mediaRows = await db

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+import { cacheLife, cacheTag } from "next/cache";
+
+import { db, media, user } from "@tsuki/db";
+
+import { siteUrl } from "@/shared/lib/site";
+import { buildSitemapEntries } from "@/shared/lib/sitemap";
+
+/** Cached so crawlers don't hit Postgres on every fetch; tags let re-syncs bust it. */
+async function getSitemapData() {
+  "use cache: remote";
+  cacheLife("max");
+  cacheTag("media", "profiles");
+
+  const mediaRows = await db
+    .select({ id: media.id, type: media.type, updatedAt: media.updatedAt })
+    .from(media);
+  const usernames = await db.select({ username: user.username }).from(user);
+
+  return { mediaRows, usernames };
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const { mediaRows, usernames } = await getSitemapData();
+  return buildSitemapEntries(siteUrl, mediaRows, usernames);
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { connection } from "next/server";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { db, media, user } from "@tsuki/db";
@@ -21,6 +22,9 @@ async function getSitemapData() {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Never prerender at build time: CI has no database access, and a build-baked
+  // sitemap would go stale anyway. The cached query keeps request-time cost low.
+  await connection();
   const { mediaRows, usernames } = await getSitemapData();
   return buildSitemapEntries(siteUrl, mediaRows, usernames);
 }

--- a/apps/web/src/features/media/components/media-json-ld.tsx
+++ b/apps/web/src/features/media/components/media-json-ld.tsx
@@ -1,0 +1,35 @@
+import { siteUrl } from "@/shared/lib/site";
+
+import { getMedia } from "../data";
+import { mediaSlug, normalizeMedia, parseMediaId } from "../media";
+
+type MediaJsonLdProps = {
+  mediaType: "ANIME" | "MANGA";
+  id: string;
+};
+
+export async function MediaJsonLd({ mediaType, id }: MediaJsonLdProps) {
+  const mediaId = parseMediaId(id);
+  if (!mediaId) return null;
+
+  const media = await getMedia(mediaType, mediaId);
+  if (!media) return null;
+
+  const normalized = normalizeMedia(media);
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": mediaType === "ANIME" ? "TVSeries" : "Book",
+          name: normalized.title,
+          description: normalized.descriptionText,
+          url: `${siteUrl}/${mediaSlug(mediaType)}/${mediaId}`,
+          image: normalized.coverImage ?? undefined,
+        }),
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/media/components/media-json-ld.tsx
+++ b/apps/web/src/features/media/components/media-json-ld.tsx
@@ -28,7 +28,7 @@ export async function MediaJsonLd({ mediaType, id }: MediaJsonLdProps) {
           description: normalized.descriptionText,
           url: `${siteUrl}/${mediaSlug(mediaType)}/${mediaId}`,
           image: normalized.coverImage ?? undefined,
-        }),
+        }).replace(/</g, "\\u003c"),
       }}
     />
   );

--- a/apps/web/src/features/media/data.ts
+++ b/apps/web/src/features/media/data.ts
@@ -6,8 +6,9 @@ import { cacheLife, cacheTag } from "next/cache";
 import type { MediaType } from "@tsuki/api/types";
 
 import { publicApi } from "@/shared/lib/public-api";
+import { siteName } from "@/shared/lib/site";
 
-import { normalizeMedia, parseMediaId } from "./media";
+import { mediaSlug, normalizeMedia, parseMediaId } from "./media";
 
 /**
  * Tagged so a re-sync from AniList can bust a single title. The API serves this
@@ -34,16 +35,33 @@ export async function getMedia(mediaType: MediaType, id: number) {
 
 export async function getMediaMetadata(mediaType: MediaType, id: string): Promise<Metadata> {
   const mediaId = parseMediaId(id);
-  if (!mediaId) return { title: "Media not found" };
+  if (!mediaId) return notFoundMetadata();
 
   const media = await getMedia(mediaType, mediaId);
-  if (!media) return { title: "Media not found" };
+  if (!media) return notFoundMetadata();
 
-  const { bannerImage: image, title, descriptionText } = normalizeMedia(media);
+  const { title, descriptionText } = normalizeMedia(media);
+  const description = descriptionText.slice(0, 160);
+  const url = `/${mediaSlug(mediaType)}/${mediaId}`;
 
   return {
     title,
-    description: descriptionText.slice(0, 160),
-    openGraph: image ? { images: [image] } : undefined,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: mediaType === "ANIME" ? "video.tv_show" : "book",
+      url,
+      title,
+      description,
+      siteName: siteName,
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+function notFoundMetadata(): Metadata {
+  return {
+    title: "Media not found",
+    robots: { index: false, follow: false },
   };
 }

--- a/apps/web/src/features/media/normalize.ts
+++ b/apps/web/src/features/media/normalize.ts
@@ -67,6 +67,11 @@ export function normalizeMediaCompact(media: MediaCompact): NormalizedMediaCompa
 
 export const MAX_MEDIA_ID = 2_147_483_647;
 
+/** URL segment for a media type — the only place the mapping lives. */
+export function mediaSlug(type: "ANIME" | "MANGA") {
+  return type === "ANIME" ? "anime" : "manga";
+}
+
 export function parseMediaId(value: string) {
   if (!/^[1-9]\d*$/.test(value)) return null;
 

--- a/apps/web/src/features/media/og-image.tsx
+++ b/apps/web/src/features/media/og-image.tsx
@@ -1,0 +1,21 @@
+import { ImageResponse } from "next/og";
+
+import { OgCard } from "@/shared/components/og-card";
+import { buildMediaOgCard, buildMinimalOgCard } from "@/shared/lib/og-card";
+
+import { getMedia } from "./data";
+import { normalizeMedia, parseMediaId } from "./media";
+
+export const ogImageSize = { width: 1200, height: 630 };
+
+/** Shared body for the per-route opengraph-image files, which Next requires one-per-route. */
+export async function renderMediaOgImage(mediaType: "ANIME" | "MANGA", id: string) {
+  const mediaId = parseMediaId(id);
+  const media = mediaId ? await getMedia(mediaType, mediaId) : null;
+
+  const layout = media
+    ? buildMediaOgCard(normalizeMedia(media))
+    : buildMinimalOgCard("Tsuki", "Track anime & manga.");
+
+  return new ImageResponse(<OgCard layout={layout} />, ogImageSize);
+}

--- a/apps/web/src/features/profile/components/profile-json-ld.tsx
+++ b/apps/web/src/features/profile/components/profile-json-ld.tsx
@@ -1,0 +1,29 @@
+import { richContentText } from "@tsuki/rich-content";
+
+import { siteUrl } from "@/shared/lib/site";
+
+import { getProfileOverview } from "../data";
+
+export async function ProfileJsonLd({ username }: { username: string }) {
+  const profile = await getProfileOverview(username);
+  if (!profile) return null;
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "ProfilePage",
+          mainEntity: {
+            "@type": "Person",
+            name: profile.user.displayUsername,
+            alternateName: `@${profile.user.username}`,
+            description: richContentText(profile.profile?.bio).trim() || undefined,
+            url: `${siteUrl}/${username}`,
+          },
+        }),
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/profile/components/profile-json-ld.tsx
+++ b/apps/web/src/features/profile/components/profile-json-ld.tsx
@@ -22,7 +22,7 @@ export async function ProfileJsonLd({ username }: { username: string }) {
             description: richContentText(profile.profile?.bio).trim() || undefined,
             url: `${siteUrl}/${username}`,
           },
-        }),
+        }).replace(/</g, "\\u003c"),
       }}
     />
   );

--- a/apps/web/src/features/profile/data.ts
+++ b/apps/web/src/features/profile/data.ts
@@ -10,6 +10,7 @@ import { richContentText } from "@tsuki/rich-content";
 import { parseUsername } from "@/shared/lib/username";
 import { publicApi } from "@/shared/lib/public-api";
 import { getServerApi } from "@/shared/lib/server-api";
+import { siteName } from "@/shared/lib/site";
 
 type ProfileSection = "followers" | "following" | "library" | "overview" | "reviews";
 
@@ -102,12 +103,30 @@ export async function getProfileViewerRelationship(username: string) {
 
 export async function getProfileMetadata(username: string): Promise<Metadata> {
   const profile = await getProfileOverview(username);
-  if (!profile) return { title: "Profile not found" };
+  if (!profile) {
+    return {
+      title: "Profile not found",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const name = profile.user.displayUsername;
+  const description =
+    richContentText(profile.profile?.bio).trim().slice(0, 160) ||
+    `View @${profile.user.username} on Tsuki.`;
+  const url = `/${username}`;
 
   return {
-    title: profile.user.displayUsername,
-    description:
-      richContentText(profile.profile?.bio).trim().slice(0, 160) ||
-      `View @${profile.user.username} on Tsuki.`,
+    title: name,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "profile",
+      url,
+      title: name,
+      description,
+      siteName: siteName,
+    },
+    twitter: { card: "summary_large_image", title: name, description },
   };
 }

--- a/apps/web/src/shared/components/og-card.tsx
+++ b/apps/web/src/shared/components/og-card.tsx
@@ -1,0 +1,152 @@
+import type { OgCardLayout } from "@/shared/lib/og-card";
+
+const SIZE = { width: 1200, height: 630 };
+
+const OVERLAY =
+  "linear-gradient(to top, rgba(10,10,10,0.95) 20%, rgba(10,10,10,0.35) 70%, rgba(10,10,10,0.15))";
+
+function Wordmark() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        color: "white",
+        fontSize: 36,
+        fontWeight: 700,
+        letterSpacing: "-0.02em",
+      }}
+    >
+      Tsuki
+    </div>
+  );
+}
+
+function MediaTitle({
+  layout,
+}: {
+  layout: Extract<OgCardLayout, { variant: "banner" | "fallback" }>;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <div
+        style={{
+          display: "flex",
+          color: "rgba(255,255,255,0.75)",
+          fontSize: 30,
+          textTransform: "uppercase",
+          letterSpacing: "0.1em",
+        }}
+      >
+        {layout.kicker}
+      </div>
+      <div
+        style={{ display: "flex", color: "white", fontSize: 76, fontWeight: 700, lineHeight: 1.1 }}
+      >
+        {layout.title}
+      </div>
+    </div>
+  );
+}
+
+function CoverThumb({ url }: { url: string | null }) {
+  if (!url) return null;
+
+  return (
+    <img
+      src={url}
+      alt=""
+      width={190}
+      height={280}
+      style={{ borderRadius: 14, objectFit: "cover" }}
+    />
+  );
+}
+
+/** Satori JSX for OG cards. Layout decisions live in @/shared/lib/og-card; this only renders. */
+export function OgCard({ layout }: { layout: OgCardLayout }) {
+  if (layout.variant === "minimal") {
+    return (
+      <div
+        style={{
+          ...SIZE,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: 64,
+          background: "#0a0a0a",
+        }}
+      >
+        <Wordmark />
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          <div style={{ display: "flex", color: "white", fontSize: 96, fontWeight: 700 }}>
+            {layout.title}
+          </div>
+          {layout.description ? (
+            <div style={{ display: "flex", color: "rgba(255,255,255,0.65)", fontSize: 36 }}>
+              {layout.description}
+            </div>
+          ) : null}
+        </div>
+        <div style={{ display: "flex", color: "rgba(255,255,255,0.4)", fontSize: 28 }}>
+          tsuki.fun
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        ...SIZE,
+        display: "flex",
+        position: "relative",
+        color: "white",
+      }}
+    >
+      {layout.variant === "banner" ? (
+        <img
+          src={layout.bannerUrl}
+          alt={layout.title}
+          width={SIZE.width}
+          height={SIZE.height}
+          style={{ position: "absolute", inset: 0, objectFit: "cover" }}
+        />
+      ) : layout.coverUrl ? (
+        // ponytail: satori's blur support is the bet here; if a render limitation
+        // appears, degrade to a darker solid overlay rather than dropping the fallback.
+        <img
+          src={layout.coverUrl}
+          alt=""
+          width={SIZE.width}
+          height={SIZE.height}
+          style={{
+            position: "absolute",
+            inset: 0,
+            objectFit: "cover",
+            transform: "scale(1.2)",
+            filter: "blur(48px)",
+          }}
+        />
+      ) : (
+        <div style={{ position: "absolute", inset: 0, display: "flex", background: "#0a0a0a" }} />
+      )}
+      <div style={{ position: "absolute", inset: 0, display: "flex", backgroundImage: OVERLAY }} />
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: 56,
+        }}
+      >
+        <Wordmark />
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 32 }}>
+          <CoverThumb url={layout.coverUrl} />
+          <MediaTitle layout={layout} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/lib/og-card.ts
+++ b/apps/web/src/shared/lib/og-card.ts
@@ -1,0 +1,67 @@
+export type OgCardLayout =
+  | {
+      variant: "banner";
+      kicker: string;
+      title: string;
+      bannerUrl: string;
+      coverUrl: string | null;
+    }
+  | {
+      variant: "fallback";
+      kicker: string;
+      title: string;
+      coverUrl: string;
+    }
+  | {
+      variant: "minimal";
+      title: string;
+      description: string | null;
+    };
+
+type MediaOgInput = {
+  title: string;
+  type: "ANIME" | "MANGA";
+  bannerImage: string | null;
+  coverImage: string | null;
+};
+
+/**
+ * The one branching decision in OG image generation: which card layout a given
+ * input gets. Pure so it can be tested without touching Satori.
+ */
+export function buildMediaOgCard({
+  title,
+  type,
+  bannerImage,
+  coverImage,
+}: MediaOgInput): OgCardLayout {
+  if (bannerImage) {
+    return {
+      variant: "banner",
+      kicker: type === "ANIME" ? "Anime" : "Manga",
+      title,
+      bannerUrl: bannerImage,
+      coverUrl: coverImage,
+    };
+  }
+
+  // Same treatment as the in-app media banner: cover scaled up and blurred
+  // behind a gradient, so cards stay intentional without banner art.
+  return {
+    variant: "fallback",
+    kicker: type === "ANIME" ? "Anime" : "Manga",
+    title,
+    coverUrl: coverImage ?? "",
+  };
+}
+
+export function buildMinimalOgCard(title: string, description: string | null): OgCardLayout {
+  return { variant: "minimal", title, description };
+}
+
+export function buildProfileOgCard(profile: {
+  displayUsername: string;
+  bio: string | null;
+}): OgCardLayout {
+  return buildMinimalOgCard(profile.displayUsername, profile.bio);
+}

--- a/apps/web/src/shared/lib/site.ts
+++ b/apps/web/src/shared/lib/site.ts
@@ -1,0 +1,12 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://tsuki.fun";
+
+/** Canonical production origin; metadataBase, canonicals, sitemap and OG URLs all hang off it. */
+export const siteUrl = SITE_URL.replace(/\/$/, "");
+
+export const siteName = "Tsuki";
+
+export const siteTagline = `${siteName} — Track anime & manga`;
+
+export const siteDescription = "Track, rate, and review anime and manga.";
+
+export const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION || null;

--- a/apps/web/src/shared/lib/sitemap.ts
+++ b/apps/web/src/shared/lib/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from "next";
+
+import { mediaSlug } from "@/features/media/media";
+
+export type SitemapMediaRow = { id: number; type: "ANIME" | "MANGA"; updatedAt: Date };
+
+/** Flat URL assembly from DB rows — kept pure so it can be tested without a database. */
+export function buildSitemapEntries(
+  siteUrl: string,
+  media: SitemapMediaRow[],
+  usernames: { username: string }[],
+): MetadataRoute.Sitemap {
+  return [
+    { url: siteUrl, changeFrequency: "daily", priority: 1 },
+    ...media.map((row) => ({
+      url: `${siteUrl}/${mediaSlug(row.type)}/${row.id}`,
+      lastModified: row.updatedAt,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
+    ...usernames.map(({ username }) => ({
+      url: `${siteUrl}/${username}`,
+      changeFrequency: "daily" as const,
+      priority: 0.6,
+    })),
+  ];
+}

--- a/apps/web/tests/shared/lib/og-card.test.ts
+++ b/apps/web/tests/shared/lib/og-card.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { buildMediaOgCard, buildProfileOgCard } from "@/shared/lib/og-card";
+
+describe("og card layout", () => {
+  test("media with banner art uses the full-bleed banner layout", () => {
+    const layout = buildMediaOgCard({
+      title: "Frieren",
+      type: "ANIME",
+      bannerImage: "https://s4.anilist.co/banner.jpg",
+      coverImage: "https://s4.anilist.co/cover.jpg",
+    });
+
+    expect(layout).toEqual({
+      variant: "banner",
+      kicker: "Anime",
+      title: "Frieren",
+      bannerUrl: "https://s4.anilist.co/banner.jpg",
+      coverUrl: "https://s4.anilist.co/cover.jpg",
+    });
+  });
+
+  test("media without banner art falls back to the blurred-cover layout", () => {
+    const layout = buildMediaOgCard({
+      title: "Frieren",
+      type: "MANGA",
+      bannerImage: null,
+      coverImage: "https://s4.anilist.co/cover.jpg",
+    });
+
+    expect(layout).toEqual({
+      variant: "fallback",
+      kicker: "Manga",
+      title: "Frieren",
+      coverUrl: "https://s4.anilist.co/cover.jpg",
+    });
+  });
+
+  test("profiles render the minimal cover-less layout", () => {
+    const layout = buildProfileOgCard({
+      displayUsername: "Mugi",
+      bio: "Tea enjoyer.",
+    });
+
+    expect(layout).toEqual({
+      variant: "minimal",
+      title: "Mugi",
+      description: "Tea enjoyer.",
+    });
+  });
+});

--- a/apps/web/tests/shared/lib/sitemap.test.ts
+++ b/apps/web/tests/shared/lib/sitemap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { buildSitemapEntries } from "@/shared/lib/sitemap";
+
+describe("sitemap assembly", () => {
+  test("builds home, media, and profile URLs with canonical casing", () => {
+    const entries = buildSitemapEntries(
+      "https://tsuki.fun",
+      [
+        { id: 21, type: "ANIME", updatedAt: new Date("2026-01-02T00:00:00Z") },
+        { id: 5, type: "MANGA", updatedAt: new Date("2026-01-01T00:00:00Z") },
+      ],
+      [{ username: "mugi_tea" }],
+    );
+
+    expect(entries).toEqual([
+      { url: "https://tsuki.fun", changeFrequency: "daily", priority: 1 },
+      {
+        url: "https://tsuki.fun/anime/21",
+        lastModified: new Date("2026-01-02T00:00:00Z"),
+        changeFrequency: "weekly",
+        priority: 0.7,
+      },
+      {
+        url: "https://tsuki.fun/manga/5",
+        lastModified: new Date("2026-01-01T00:00:00Z"),
+        changeFrequency: "weekly",
+        priority: 0.7,
+      },
+      { url: "https://tsuki.fun/mugi_tea", changeFrequency: "daily", priority: 0.6 },
+    ]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@tsuki/anilist": "workspace:*",
         "@tsuki/api": "workspace:*",
         "@tsuki/auth": "workspace:*",
+        "@tsuki/db": "workspace:*",
         "@tsuki/env": "workspace:*",
         "@tsuki/rich-content": "workspace:*",
         "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
- Rewrite root metadata: `metadataBase`, title template, full OG/Twitter/`appleWebApp` blocks, env-driven Google Search Console verification
- Rewrite media and profile metadata: full OG blocks, canonical URLs, per-type `og:type`
- Add dynamic OG image cards (banner, blurred-cover fallback, minimal layouts) for home, media, and profile routes
- Add dynamic sitemap built from a cached DB query (media + usernames)
- Add robots policy (admin, API, social, and auth pages disallowed) and PWA manifest
- Add JSON-LD: `WebSite` with search action at root, media and `ProfilePage` structured data
- Add noindex to admin, auth, and gated social surfaces
- Cover the OG layout decision and sitemap assembly with unit tests