### PR TITLE
impr(web): discord-style image editing and social link presets in edit profile

### DIFF
--- a/apps/api/src/modules/profiles/index.ts
+++ b/apps/api/src/modules/profiles/index.ts
@@ -63,10 +63,15 @@ export const profilesRoutes = new Elysia({ tags: ["Profiles"] })
 
       let bio: RichContent | null | undefined;
       if (rawBio !== undefined) {
-        const parsed = validateRichContent(rawBio, "bio");
-        if (!parsed.ok) return status(422, { error: parsed.reason });
-        // An empty bio stores as null, keeping one representation of "none".
-        bio = isEmptyRichContent(parsed.value) ? null : parsed.value;
+        // A cleared bio arrives as null from the form; an empty doc collapses
+        // to null too, keeping one representation of "none".
+        if (rawBio === null) {
+          bio = null;
+        } else {
+          const parsed = validateRichContent(rawBio, "bio");
+          if (!parsed.ok) return status(422, { error: parsed.reason });
+          bio = isEmptyRichContent(parsed.value) ? null : parsed.value;
+        }
       }
 
       // Uploaded images must carry the server-mandated naming convention bound

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
     "react-dom": "19.2.4",
     "recharts": "3.8.0",
     "shadcn": "^4.11.0",
+    "simple-icons": "^16.29.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",

--- a/apps/web/src/features/profile/components/edit-profile-dialog.tsx
+++ b/apps/web/src/features/profile/components/edit-profile-dialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { revalidateLogic, useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
-import { Edit2, LoaderCircle, Plus, Trash2 } from "lucide-react";
+import { Edit2, LoaderCircle, Plus, User, X } from "lucide-react";
 import { toast } from "sonner";
 
 import type { UserOverview } from "@tsuki/api/types";
@@ -23,14 +24,24 @@ import {
   DialogTrigger,
 } from "@/shared/components/ui/dialog";
 import { Field, FieldGroup, FieldLabel, FieldLegend, FieldSet } from "@/shared/components/ui/field";
+import { cn } from "@/shared/lib/utils";
 import { TextField } from "@/shared/components/text-field";
 
+import type { ImageUploadType } from "../image-utils";
 import { updateProfile } from "../actions";
-import { createProfileUpdate, profileFormSchema, type ProfileFormValues } from "../schemas";
+import { createProfileFormValues, createProfileUpdate, profileFormSchema } from "../schemas";
+import { ProfileImageControls } from "./profile-image-controls";
+import { getSocialPreset, SOCIAL_PRESETS, SocialIcon } from "../social-presets";
 
-export function EditProfileDialog({ profile }: { profile: UserOverview["profile"] }) {
+export function EditProfileDialog({
+  profile,
+  avatarImage,
+}: {
+  profile: UserOverview["profile"];
+  avatarImage?: string | null;
+}) {
   const router = useRouter();
-  const defaultValues = createProfileFormValues(profile);
+  const defaultValues = createProfileFormValues(profile, avatarImage);
   const update = useMutation({ mutationFn: updateProfile });
 
   const form = useForm({
@@ -38,10 +49,12 @@ export function EditProfileDialog({ profile }: { profile: UserOverview["profile"
     validationLogic: revalidateLogic(),
     validators: { onDynamic: profileFormSchema },
     onSubmit: async ({ value }) => {
-      const result = await update.mutateAsync(createProfileUpdate(value)).catch(() => {
-        toast.error("An unexpected error occurred.");
-        throw new Error("Failed to update profile");
-      });
+      const result = await update
+        .mutateAsync(createProfileUpdate(value, defaultValues))
+        .catch(() => {
+          toast.error("An unexpected error occurred.");
+          throw new Error("Failed to update profile");
+        });
       if (!result.success) {
         toast.error(result.error);
         throw new Error(result.error);
@@ -71,7 +84,7 @@ export function EditProfileDialog({ profile }: { profile: UserOverview["profile"
           </Button>
         }
       />
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[500px]">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
         <DialogHeader>
           <DialogTitle>Edit Profile</DialogTitle>
         </DialogHeader>
@@ -88,6 +101,28 @@ export function EditProfileDialog({ profile }: { profile: UserOverview["profile"
             {(isSubmitting) => (
               <FieldSet disabled={isSubmitting}>
                 <FieldGroup>
+                  <form.Field name="bannerImage">
+                    {(field) => (
+                      <ProfileImageField
+                        type="banner"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.Field>
+
+                  <div className="-mt-12 px-2">
+                    <form.Field name="image">
+                      {(field) => (
+                        <ProfileImageField
+                          type="avatar"
+                          value={field.state.value}
+                          onChange={field.handleChange}
+                        />
+                      )}
+                    </form.Field>
+                  </div>
+
                   <form.Field name="bio">
                     {(field) => (
                       <Field>
@@ -104,65 +139,110 @@ export function EditProfileDialog({ profile }: { profile: UserOverview["profile"
                     )}
                   </form.Field>
 
-                  <TextField
-                    form={form}
-                    name="bannerImage"
-                    label="Banner Image URL"
-                    type="url"
-                    placeholder="https://example.com/banner.jpg"
-                  />
-
                   <form.Field name="socialLinks" mode="array">
-                    {(socialLinksField) => (
-                      <FieldSet className="grid grid-cols-[1fr_auto] items-center">
-                        <FieldLegend variant="label" className="mb-0">
-                          Social Links
-                        </FieldLegend>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => socialLinksField.pushValue({ platform: "", url: "" })}
-                        >
-                          <Plus data-icon="inline-start" />
-                          Add Link
-                        </Button>
-                        <FieldGroup className="col-span-2">
-                          {socialLinksField.state.value.map((link, index) => (
-                            <FieldGroup
-                              key={index}
-                              className="grid grid-cols-[1fr_2fr_auto] items-start gap-2"
-                            >
-                              <TextField
-                                form={form}
-                                name={`socialLinks[${index}].platform`}
-                                label={`Platform ${index + 1}`}
-                                hideLabel
-                                placeholder="Platform"
-                              />
-                              <TextField
-                                form={form}
-                                name={`socialLinks[${index}].url`}
-                                label={`URL ${index + 1}`}
-                                hideLabel
-                                type="url"
-                                placeholder="https://x.com/..."
-                              />
-                              <Button
+                    {(socialLinksField) => {
+                      const usedPlatforms = new Set(
+                        socialLinksField.state.value.map((link) =>
+                          link.platform.trim().toLowerCase(),
+                        ),
+                      );
+
+                      return (
+                        <FieldSet>
+                          <FieldLegend variant="label">Social Links</FieldLegend>
+
+                          <div className="flex flex-wrap gap-2">
+                            {SOCIAL_PRESETS.map((preset) => (
+                              <button
+                                key={preset.value}
                                 type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="mt-0.5 shrink-0 text-destructive"
-                                onClick={() => socialLinksField.removeValue(index)}
-                                aria-label={`Remove ${link.platform || "social"} link`}
+                                title={`Add ${preset.label} link`}
+                                aria-label={`Add ${preset.label} link`}
+                                disabled={usedPlatforms.has(preset.value)}
+                                className="flex h-9 w-9 items-center justify-center rounded-full border border-border/50 bg-muted/50 text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary disabled:pointer-events-none disabled:opacity-40"
+                                onClick={() =>
+                                  socialLinksField.pushValue({ platform: preset.value, url: "" })
+                                }
                               >
-                                <Trash2 />
-                              </Button>
-                            </FieldGroup>
-                          ))}
-                        </FieldGroup>
-                      </FieldSet>
-                    )}
+                                <SocialIcon preset={preset} className="h-4 w-4" />
+                              </button>
+                            ))}
+                            <button
+                              type="button"
+                              title="Add custom link"
+                              aria-label="Add custom link"
+                              className="flex h-9 w-9 items-center justify-center rounded-full border border-dashed border-border/50 text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+                              onClick={() => socialLinksField.pushValue({ platform: "", url: "" })}
+                            >
+                              <Plus className="h-4 w-4" />
+                            </button>
+                          </div>
+
+                          <FieldGroup>
+                            {socialLinksField.state.value.map((link, index) => {
+                              const preset = getSocialPreset(link.platform);
+
+                              return (
+                                <FieldGroup
+                                  key={index}
+                                  className={cn(
+                                    "grid items-start gap-2",
+                                    preset
+                                      ? "grid-cols-[auto_1fr_auto]"
+                                      : "grid-cols-[1fr_2fr_auto]",
+                                  )}
+                                >
+                                  {preset ? (
+                                    <>
+                                      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-border/50 bg-muted/50 text-muted-foreground">
+                                        <SocialIcon preset={preset} className="h-4 w-4" />
+                                      </div>
+                                      <TextField
+                                        form={form}
+                                        name={`socialLinks[${index}].url`}
+                                        label={preset.label}
+                                        hideLabel
+                                        placeholder={preset.placeholder}
+                                        inputMode={preset.prefix ? "text" : "url"}
+                                      />
+                                    </>
+                                  ) : (
+                                    <>
+                                      <TextField
+                                        form={form}
+                                        name={`socialLinks[${index}].platform`}
+                                        label={`Platform ${index + 1}`}
+                                        hideLabel
+                                        placeholder="platform"
+                                      />
+                                      <TextField
+                                        form={form}
+                                        name={`socialLinks[${index}].url`}
+                                        label={`URL ${index + 1}`}
+                                        hideLabel
+                                        placeholder="d1rshan.me"
+                                        inputMode="url"
+                                      />
+                                    </>
+                                  )}
+
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="mt-0.5 shrink-0"
+                                    onClick={() => socialLinksField.removeValue(index)}
+                                    aria-label={`Remove ${link.platform || "social"} link`}
+                                  >
+                                    <X />
+                                  </Button>
+                                </FieldGroup>
+                              );
+                            })}
+                          </FieldGroup>
+                        </FieldSet>
+                      );
+                    }}
                   </form.Field>
 
                   <div className="flex justify-end gap-2 pt-2">
@@ -195,13 +275,63 @@ export function EditProfileDialog({ profile }: { profile: UserOverview["profile"
   );
 }
 
-function createProfileFormValues(profile: UserOverview["profile"]): ProfileFormValues {
-  return {
-    bio: profile?.bio ?? null,
-    bannerImage: profile?.bannerImage || "",
-    socialLinks: Object.entries(profile?.socialLinks ?? {}).map(([platform, url]) => ({
-      platform,
-      url,
-    })),
-  };
+function ProfileImageField({
+  type,
+  value,
+  onChange,
+}: {
+  type: ImageUploadType;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}) {
+  const isBanner = type === "banner";
+
+  if (isBanner) {
+    return (
+      <div className="relative w-full">
+        <div className="relative h-40 w-full overflow-hidden rounded-2xl border">
+          {value ? (
+            <Image src={value} alt="Banner preview" fill unoptimized className="object-cover" />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-tr from-muted/50 via-muted/20 to-muted/50" />
+          )}
+        </div>
+
+        <ProfileImageControls
+          type="banner"
+          aspectRatio={3}
+          cropShape="rect"
+          hasImage={Boolean(value)}
+          onUploadSuccess={onChange}
+          onRemove={() => onChange(null)}
+          className="absolute bottom-2 right-2"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-24 w-24 shrink-0">
+      <div className="relative h-24 w-24 overflow-hidden rounded-full border bg-muted ring-4 ring-background">
+        {value ? (
+          <Image src={value} alt="Avatar preview" fill className="object-cover" />
+        ) : (
+          <div className="grid h-full w-full place-items-center text-muted-foreground">
+            <User className="h-8 w-8" />
+          </div>
+        )}
+      </div>
+
+      <ProfileImageControls
+        type="avatar"
+        align="start"
+        aspectRatio={1}
+        cropShape="round"
+        hasImage={Boolean(value)}
+        onUploadSuccess={onChange}
+        onRemove={() => onChange(null)}
+        className="absolute right-0 bottom-0 z-10"
+      />
+    </div>
+  );
 }

--- a/apps/web/src/features/profile/components/profile-avatar.tsx
+++ b/apps/web/src/features/profile/components/profile-avatar.tsx
@@ -1,47 +1,19 @@
-"use client";
-
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 
 import type { UserOverview } from "@tsuki/api/types";
 
 import { cn } from "@/shared/lib/utils";
 
-import { updateProfile } from "../actions";
-import { ProfileImageControls } from "./profile-image-controls";
-
 type ProfileAvatarProps = {
   className?: string;
-  isOwner?: boolean;
   user: UserOverview["user"];
 };
 
-export function ProfileAvatar({ className, isOwner = false, user }: ProfileAvatarProps) {
-  const router = useRouter();
-
-  const handleUploadSuccess = async (url: string) => {
-    const result = await updateProfile({ image: url });
-    // Throw so the crop dialog stays open and the user can retry.
-    if (!result.success) throw new Error(result.error || "Failed to update avatar.");
-    toast.success("Avatar updated");
-    router.refresh();
-  };
-
-  const handleRemoveAvatar = async () => {
-    const result = await updateProfile({ image: null });
-    if (!result.success) {
-      toast.error(result.error || "Failed to remove avatar.");
-      return;
-    }
-    toast.success("Avatar removed");
-    router.refresh();
-  };
-
+export function ProfileAvatar({ className, user }: ProfileAvatarProps) {
   return (
     <div
       className={cn(
-        "group/avatar relative h-24 w-24 overflow-hidden rounded-full border bg-muted ring-4 ring-background shadow-sm md:h-32 md:w-32",
+        "relative h-24 w-24 overflow-hidden rounded-full border bg-muted ring-4 ring-background shadow-sm md:h-32 md:w-32",
         className,
       )}
     >
@@ -57,19 +29,6 @@ export function ProfileAvatar({ className, isOwner = false, user }: ProfileAvata
       ) : (
         <div className="grid h-full w-full place-items-center text-3xl font-medium text-muted-foreground">
           {user.displayUsername.charAt(0).toUpperCase()}
-        </div>
-      )}
-
-      {isOwner && (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-200 group-hover/avatar:opacity-100 focus-within:opacity-100">
-          <ProfileImageControls
-            type="avatar"
-            aspectRatio={1}
-            cropShape="round"
-            hasImage={Boolean(user.image)}
-            onUploadSuccess={handleUploadSuccess}
-            onRemove={handleRemoveAvatar}
-          />
         </div>
       )}
     </div>

--- a/apps/web/src/features/profile/components/profile-banner.tsx
+++ b/apps/web/src/features/profile/components/profile-banner.tsx
@@ -1,48 +1,15 @@
-"use client";
-
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 
 import { cn } from "@/shared/lib/utils";
-
-import { updateProfile } from "../actions";
-import { ProfileImageControls } from "./profile-image-controls";
 
 type ProfileBannerProps = {
   bannerImage?: string | null;
   className?: string;
-  isOwner?: boolean;
 };
 
-export function ProfileBanner({ bannerImage, className, isOwner = false }: ProfileBannerProps) {
-  const router = useRouter();
-
-  const handleUploadSuccess = async (url: string) => {
-    const result = await updateProfile({ bannerImage: url });
-    // Throw so the crop dialog stays open and the user can retry.
-    if (!result.success) throw new Error(result.error || "Failed to update banner.");
-    toast.success("Banner updated");
-    router.refresh();
-  };
-
-  const handleRemoveBanner = async () => {
-    const result = await updateProfile({ bannerImage: null });
-    if (!result.success) {
-      toast.error(result.error || "Failed to remove banner.");
-      return;
-    }
-    toast.success("Banner removed");
-    router.refresh();
-  };
-
+export function ProfileBanner({ bannerImage, className }: ProfileBannerProps) {
   return (
-    <div
-      className={cn(
-        "group/banner relative mb-6 w-full overflow-hidden rounded-2xl border",
-        className,
-      )}
-    >
+    <div className={cn("relative mb-6 w-full overflow-hidden rounded-2xl border", className)}>
       {bannerImage ? (
         <div className="relative h-48 w-full overflow-hidden shadow-sm md:h-64">
           <Image
@@ -59,19 +26,6 @@ export function ProfileBanner({ bannerImage, className, isOwner = false }: Profi
       )}
 
       <div className="absolute inset-0 bg-gradient-to-t from-background/30 to-transparent" />
-
-      {isOwner && (
-        <div className="absolute top-3 right-3 z-10 opacity-0 transition-opacity duration-200 group-hover/banner:opacity-100 focus-within:opacity-100 md:top-4 md:right-4">
-          <ProfileImageControls
-            type="banner"
-            aspectRatio={3}
-            cropShape="rect"
-            hasImage={Boolean(bannerImage)}
-            onUploadSuccess={handleUploadSuccess}
-            onRemove={handleRemoveBanner}
-          />
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/web/src/features/profile/components/profile-bio-card.tsx
+++ b/apps/web/src/features/profile/components/profile-bio-card.tsx
@@ -3,42 +3,65 @@ import { Link as LinkIcon } from "lucide-react";
 import type { UserOverview } from "@tsuki/api/types";
 
 import { RichContentView } from "@/features/rich-content/components/rich-content-view";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/shared/components/ui/tooltip";
 
 import { cn } from "@/shared/lib/utils";
 
 import { BENTO_CARD } from "./profile-section";
+import { getSocialPreset, SocialIcon } from "../social-presets";
 
 type Profile = UserOverview["profile"];
 
 export function ProfileBioCard({ className, profile }: { className?: string; profile: Profile }) {
   const socialLinks = profile?.socialLinks;
+  const hasBio = Boolean(profile?.bio);
 
   return (
     <div className={cn(BENTO_CARD, "flex flex-col p-5 sm:p-6", className)}>
-      {profile?.bio ? (
+      {hasBio && (
         <RichContentView
-          content={profile.bio}
+          content={profile?.bio}
           mode="compact"
           className="mt-3 text-sm leading-relaxed text-foreground/80"
         />
-      ) : (
-        <p className="mt-3 text-sm text-muted-foreground">Nothing here yet.</p>
       )}
 
       {socialLinks && Object.keys(socialLinks).length > 0 && (
-        <div className="mt-auto flex flex-wrap gap-x-4 gap-y-2 pt-6">
-          {Object.entries(socialLinks).map(([platform, url]) => (
-            <a
-              key={platform}
-              href={url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
-            >
-              <LinkIcon className="h-4 w-4" />
-              <span className="capitalize">{platform}</span>
-            </a>
-          ))}
+        <div className={cn("flex flex-wrap gap-2.5", hasBio ? "mt-auto pt-6" : "mt-2")}>
+          <TooltipProvider>
+            {Object.entries(socialLinks).map(([platform, url]) => {
+              const preset = getSocialPreset(platform);
+              const name = preset?.label ?? platform;
+
+              return (
+                <Tooltip key={platform}>
+                  <TooltipTrigger
+                    render={
+                      <a
+                        href={url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={name}
+                        className="flex h-9 w-9 items-center justify-center rounded-full border border-border/50 bg-muted/50 text-muted-foreground transition-colors hover:border-primary/50 hover:text-primary"
+                      />
+                    }
+                  >
+                    {preset ? (
+                      <SocialIcon preset={preset} className="h-4 w-4" />
+                    ) : (
+                      <LinkIcon className="h-4 w-4" />
+                    )}
+                  </TooltipTrigger>
+                  <TooltipContent>{name}</TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
         </div>
       )}
     </div>

--- a/apps/web/src/features/profile/components/profile-header.tsx
+++ b/apps/web/src/features/profile/components/profile-header.tsx
@@ -6,20 +6,19 @@ import { ProfileTabs } from "./profile-tabs";
 
 type ProfileHeaderProps = {
   actions: React.ReactNode;
-  isOwner?: boolean;
   profile: UserOverview["profile"];
   user: UserOverview["user"];
 };
 
-export function ProfileHeader({ actions, isOwner = false, profile, user }: ProfileHeaderProps) {
+export function ProfileHeader({ actions, profile, user }: ProfileHeaderProps) {
   return (
     <header className="mb-8">
-      <ProfileBanner bannerImage={profile?.bannerImage} isOwner={isOwner} />
+      <ProfileBanner bannerImage={profile?.bannerImage} />
 
       <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 px-2 md:px-6">
         <div className="flex min-w-0 flex-wrap items-start gap-x-6 gap-y-3">
           <div className="-mt-16 flex shrink-0 flex-col items-center gap-2 md:-mt-20">
-            <ProfileAvatar user={user} isOwner={isOwner} />
+            <ProfileAvatar user={user} />
             <h1 className="truncate text-lg font-bold tracking-tight text-foreground md:text-xl">
               @{user.displayUsername || user.username}
             </h1>

--- a/apps/web/src/features/profile/components/profile-image-controls.tsx
+++ b/apps/web/src/features/profile/components/profile-image-controls.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { LoaderCircle, Pencil, Trash2, Upload, X } from "lucide-react";
+import { useRef, useState } from "react";
+import { ImageUp, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { apiClient } from "@/shared/lib/api-client";
 import { cn } from "@/shared/lib/utils";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/shared/components/ui/dropdown-menu";
 
 import {
   type ImageUploadType,
@@ -15,56 +22,31 @@ import {
 import { ImageCropDialog } from "./image-crop-dialog";
 
 type ProfileImageControlsProps = {
+  align?: "start" | "end";
   aspectRatio: number;
   className?: string;
   cropShape?: "round" | "rect";
-  cropTitle?: string;
   hasImage: boolean;
-  onRemove: () => Promise<void> | void;
-  onUploadSuccess: (url: string) => Promise<void> | void;
+  onRemove: () => void;
+  onUploadSuccess: (url: string) => void;
   type: ImageUploadType;
 };
 
+/** Pencil trigger that opens a menu of image actions (Discord-style). */
 export function ProfileImageControls({
+  align = "end",
   aspectRatio,
   className,
   cropShape = "rect",
-  cropTitle,
   hasImage,
   onRemove,
   onUploadSuccess,
   type,
 }: ProfileImageControlsProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploading, setIsUploading] = useState(false);
-  const [isRemoving, setIsRemoving] = useState(false);
   const [selectedFileUrl, setSelectedFileUrl] = useState<string | null>(null);
   const [isCropOpen, setIsCropOpen] = useState(false);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  // Click outside to collapse the action buttons
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent | TouchEvent) {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node) &&
-        !isCropOpen
-      ) {
-        setIsOpen(false);
-      }
-    }
-
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      document.addEventListener("touchstart", handleClickOutside);
-    }
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("touchstart", handleClickOutside);
-    };
-  }, [isOpen, isCropOpen]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -77,8 +59,7 @@ export function ProfileImageControls({
       return;
     }
 
-    const objectUrl = URL.createObjectURL(file);
-    setSelectedFileUrl(objectUrl);
+    setSelectedFileUrl(URL.createObjectURL(file));
     setIsCropOpen(true);
   };
 
@@ -105,9 +86,8 @@ export function ProfileImageControls({
 
       const uploadResult = await uploadBlobToImageKit({ blob, auth });
 
-      await onUploadSuccess(uploadResult.url);
+      onUploadSuccess(uploadResult.url);
       handleCancelCrop();
-      setIsOpen(false);
     } catch (err) {
       console.error("Upload error:", err);
       toast.error(err instanceof Error ? err.message : "Upload failed. Please try again.");
@@ -116,89 +96,43 @@ export function ProfileImageControls({
     }
   };
 
-  const handleDelete = async () => {
-    setIsRemoving(true);
-    try {
-      await onRemove();
-      setIsOpen(false);
-    } catch {
-      toast.error("Failed to remove image.");
-    } finally {
-      setIsRemoving(false);
-    }
-  };
-
-  const isBusy = isUploading || isRemoving;
-
   return (
-    <div ref={containerRef} className={cn("relative z-20 flex items-center gap-1.5", className)}>
+    <div className={cn("inline-flex", className)}>
       <input
         ref={fileInputRef}
         type="file"
         accept="image/jpeg,image/png,image/webp"
         className="hidden"
         onChange={handleFileChange}
-        disabled={isBusy}
+        disabled={isUploading}
         aria-label={`Upload ${type}`}
       />
 
-      {isBusy ? (
-        <div className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 shadow-md md:h-9 md:w-9">
-          <LoaderCircle className="h-4 w-4 animate-spin text-primary" />
-        </div>
-      ) : !isOpen ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsOpen(true);
-          }}
-          className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-foreground shadow-md transition-all duration-200 hover:scale-105 hover:border-primary/50 hover:text-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none md:h-9 md:w-9"
-          aria-label={`Edit ${type}`}
-        >
-          <Pencil className="h-4 w-4" />
-        </button>
-      ) : (
-        <div className="flex items-center gap-1.5 animate-in fade-in-0 zoom-in-95 duration-150">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              fileInputRef.current?.click();
-            }}
-            className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-foreground shadow-md transition-all duration-200 hover:scale-105 hover:border-primary hover:text-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none md:h-9 md:w-9"
-            aria-label={`Upload new ${type}`}
-          >
-            <Upload className="h-4 w-4" />
-          </button>
-
-          {hasImage && (
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
             <button
               type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                void handleDelete();
-              }}
-              className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-destructive shadow-md transition-all duration-200 hover:scale-105 hover:border-destructive/80 hover:bg-destructive/10 focus-visible:ring-2 focus-visible:ring-destructive focus-visible:outline-none md:h-9 md:w-9"
-              aria-label={`Delete ${type}`}
+              className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-foreground shadow-md transition-colors hover:border-primary/50 hover:text-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none md:h-9 md:w-9"
+              aria-label={`Edit ${type}`}
             >
-              <Trash2 className="h-4 w-4" />
+              <Pencil className="h-4 w-4" />
             </button>
+          }
+        />
+        <DropdownMenuContent align={align}>
+          <DropdownMenuItem onSelect={() => fileInputRef.current?.click()}>
+            <ImageUp />
+            Upload
+          </DropdownMenuItem>
+          {hasImage && (
+            <DropdownMenuItem variant="destructive" onSelect={onRemove}>
+              <Trash2 />
+              Remove
+            </DropdownMenuItem>
           )}
-
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsOpen(false);
-            }}
-            className="glass flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-muted-foreground shadow-md transition-all duration-200 hover:scale-105 hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none md:h-9 md:w-9"
-            aria-label="Cancel"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-      )}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <ImageCropDialog
         isOpen={isCropOpen}
@@ -206,7 +140,7 @@ export function ProfileImageControls({
         imageSrc={selectedFileUrl}
         aspectRatio={aspectRatio}
         cropShape={cropShape}
-        title={cropTitle || `Crop ${type === "avatar" ? "Avatar" : "Banner"}`}
+        title={`Crop ${type === "avatar" ? "Avatar" : "Banner"}`}
         onCancel={handleCancelCrop}
         onConfirm={handleConfirmCrop}
       />

--- a/apps/web/src/features/profile/components/profile-viewer-actions.tsx
+++ b/apps/web/src/features/profile/components/profile-viewer-actions.tsx
@@ -15,7 +15,7 @@ export async function ProfileViewerActions({
 }) {
   const { user } = await getSession();
   if (user?.id === profileUser.id) {
-    return <EditProfileDialog profile={profile} />;
+    return <EditProfileDialog profile={profile} avatarImage={profileUser.image} />;
   }
 
   const relationship = user ? await getProfileViewerRelationship(profileUser.username) : null;

--- a/apps/web/src/features/profile/layouts/profile-layout.tsx
+++ b/apps/web/src/features/profile/layouts/profile-layout.tsx
@@ -2,7 +2,6 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
 import { ProfileHeader } from "@/features/profile/components/profile-header";
-import { getSession } from "@/shared/lib/session";
 
 import { ProfileViewerActions } from "../components/profile-viewer-actions";
 import { getProfileOverview } from "../data";
@@ -14,20 +13,14 @@ export async function ProfileLayout({
   children: React.ReactNode;
   username: string;
 }) {
-  const [profile, { user: sessionUser }] = await Promise.all([
-    getProfileOverview(username),
-    getSession(),
-  ]);
+  const profile = await getProfileOverview(username);
   if (!profile) notFound();
-
-  const isOwner = sessionUser?.id === profile.user.id;
 
   return (
     <div className="min-h-screen pt-20 pb-10 md:pt-28 md:pb-16">
       <ProfileHeader
         user={profile.user}
         profile={profile.profile}
-        isOwner={isOwner}
         actions={
           <Suspense fallback={null}>
             <ProfileViewerActions profile={profile.profile} user={profile.user} />

--- a/apps/web/src/features/profile/schemas.ts
+++ b/apps/web/src/features/profile/schemas.ts
@@ -1,23 +1,30 @@
 import { z } from "zod";
 
+import type { UserOverview } from "@tsuki/api/types";
 import type { RichContent } from "@tsuki/rich-content";
 import { isEmptyRichContent } from "@tsuki/rich-content";
+
+import { getSocialPreset } from "./social-presets";
 
 const httpUrl = z.url("Enter a valid URL").refine((value) => /^https?:\/\//i.test(value), {
   message: "URL must start with http:// or https://",
 });
-const optionalHttpUrl = z.union([httpUrl, z.literal("")]);
 
 // Deep Rich Content policy is enforced by the API; the form passes it through.
 const richContent = z.custom<RichContent | null>(() => true);
 
+// URLs are forgiven on input (scheme auto-prefixed in createProfileUpdate) and
+// strictly re-validated by the server action via profileUpdateSchema.
+const socialUrl = z.string().trim().min(1, "URL is required");
+
 export const profileFormSchema = z.object({
   bio: richContent,
-  bannerImage: optionalHttpUrl,
+  image: z.string().nullable(),
+  bannerImage: z.string().nullable(),
   socialLinks: z.array(
     z.object({
       platform: z.string().trim().min(1, "Platform is required"),
-      url: httpUrl,
+      url: socialUrl,
     }),
   ),
 });
@@ -32,14 +39,55 @@ export const profileUpdateSchema = z.object({
 export type ProfileFormValues = z.infer<typeof profileFormSchema>;
 export type ProfileUpdate = z.infer<typeof profileUpdateSchema>;
 
-export function createProfileUpdate(values: ProfileFormValues): ProfileUpdate {
-  const socialLinks = Object.fromEntries(
-    values.socialLinks.map(({ platform, url }) => [platform.trim().toLowerCase(), url]),
-  );
+export function createProfileUpdate(
+  values: ProfileFormValues,
+  original: ProfileFormValues,
+): ProfileUpdate {
+  const entries: [string, string][] = values.socialLinks.map(({ platform, url }) => {
+    const key = platform.trim().toLowerCase();
+    const value = url.trim();
+    const preset = getSocialPreset(key);
+    // Presets accept a bare handle; anything URL-ish is taken as-is with the
+    // scheme auto-prefixed, then strictly re-validated by the server action.
+    const fullUrl = /^https?:\/\//i.test(value)
+      ? value
+      : preset?.prefix && !/[./]/.test(value)
+        ? preset.prefix + value.replace(/^@/, "")
+        : `https://${value}`;
+    return [key, fullUrl];
+  });
+  const socialLinks = Object.fromEntries(entries.filter(([platform, url]) => platform && url));
 
   return {
     bio: values.bio && !isEmptyRichContent(values.bio) ? values.bio : null,
-    bannerImage: values.bannerImage || null,
+    // Unchanged images are omitted so the API doesn't re-verify legacy URLs it
+    // didn't mint (foreign banner URLs from the old URL field would 422).
+    image: values.image === original.image ? undefined : values.image,
+    bannerImage: values.bannerImage === original.bannerImage ? undefined : values.bannerImage,
     socialLinks: Object.keys(socialLinks).length ? socialLinks : null,
+  };
+}
+
+/** Strips a preset's prefix so the form field shows just the handle. */
+function toFormUrl(platform: string, url: string): string {
+  const prefix = getSocialPreset(platform)?.prefix;
+  if (prefix && url.toLowerCase().startsWith(prefix)) {
+    return url.slice(prefix.length);
+  }
+  return url;
+}
+
+export function createProfileFormValues(
+  profile: UserOverview["profile"],
+  avatarImage?: string | null,
+): ProfileFormValues {
+  return {
+    bio: profile?.bio ?? null,
+    image: avatarImage ?? profile?.image ?? null,
+    bannerImage: profile?.bannerImage ?? null,
+    socialLinks: Object.entries(profile?.socialLinks ?? {}).map(([platform, url]) => ({
+      platform,
+      url: toFormUrl(platform, url),
+    })),
   };
 }

--- a/apps/web/src/features/profile/schemas.ts
+++ b/apps/web/src/features/profile/schemas.ts
@@ -70,11 +70,16 @@ export function createProfileUpdate(
   };
 }
 
-/** Strips a preset's prefix so the form field shows just the handle. */
+/** Strips a preset's prefix so the form field shows just the handle. URLs
+ * with extra path (e.g. https://github.com/owner/repo) are kept whole — only
+ * handle-shaped remainders (no slash) reduce, so saving round-trips exactly. */
 function toFormUrl(platform: string, url: string): string {
   const prefix = getSocialPreset(platform)?.prefix;
   if (prefix && url.toLowerCase().startsWith(prefix)) {
-    return url.slice(prefix.length);
+    const handle = url.slice(prefix.length);
+    if (handle && !handle.includes("/")) {
+      return handle;
+    }
   }
   return url;
 }

--- a/apps/web/src/features/profile/schemas.ts
+++ b/apps/web/src/features/profile/schemas.ts
@@ -47,11 +47,13 @@ export function createProfileUpdate(
     const key = platform.trim().toLowerCase();
     const value = url.trim();
     const preset = getSocialPreset(key);
-    // Presets accept a bare handle; anything URL-ish is taken as-is with the
-    // scheme auto-prefixed, then strictly re-validated by the server action.
+    // Presets accept a bare handle; anything with a path is taken as-is with
+    // the scheme auto-prefixed, then re-validated by the server action.
+    // (Handles may contain dots — e.g. instagram — but never slashes, so the
+    // slash check keeps dotted handles from being treated as domains.)
     const fullUrl = /^https?:\/\//i.test(value)
       ? value
-      : preset?.prefix && !/[./]/.test(value)
+      : preset?.prefix && !value.includes("/")
         ? preset.prefix + value.replace(/^@/, "")
         : `https://${value}`;
     return [key, fullUrl];

--- a/apps/web/src/features/profile/social-presets.tsx
+++ b/apps/web/src/features/profile/social-presets.tsx
@@ -1,0 +1,80 @@
+import { Globe } from "lucide-react";
+import {
+  siDiscord,
+  siGithub,
+  siInstagram,
+  siTwitch,
+  siX,
+  siYoutube,
+  type SimpleIcon,
+} from "simple-icons";
+
+export type SocialPreset = {
+  /** Lowercase platform key stored in profile.socialLinks */
+  value: string;
+  label: string;
+  /** simple-icons brand path; null renders a Globe (generic URL platforms) */
+  icon: SimpleIcon | null;
+  /**
+   * If set, users only type a handle and the full URL is built from it.
+   * Absent for generic URL platforms (e.g. website).
+   */
+  prefix?: string;
+  placeholder: string;
+};
+
+export const SOCIAL_PRESETS: SocialPreset[] = [
+  { value: "x", label: "X", icon: siX, prefix: "https://x.com/", placeholder: "username" },
+  {
+    value: "github",
+    label: "GitHub",
+    icon: siGithub,
+    prefix: "https://github.com/",
+    placeholder: "username",
+  },
+  {
+    value: "youtube",
+    label: "YouTube",
+    icon: siYoutube,
+    prefix: "https://youtube.com/@",
+    placeholder: "handle",
+  },
+  {
+    value: "twitch",
+    label: "Twitch",
+    icon: siTwitch,
+    prefix: "https://twitch.tv/",
+    placeholder: "username",
+  },
+  {
+    value: "discord",
+    label: "Discord",
+    icon: siDiscord,
+    prefix: "https://discord.com/users/",
+    placeholder: "user ID",
+  },
+  {
+    value: "instagram",
+    label: "Instagram",
+    icon: siInstagram,
+    prefix: "https://instagram.com/",
+    placeholder: "username",
+  },
+  { value: "website", label: "Website", icon: null, placeholder: "d1rshan.me" },
+];
+
+export function getSocialPreset(platform: string): SocialPreset | undefined {
+  return SOCIAL_PRESETS.find((preset) => preset.value === platform.trim().toLowerCase());
+}
+
+export function SocialIcon({ preset, className }: { preset: SocialPreset; className?: string }) {
+  if (!preset.icon) {
+    return <Globe className={className} aria-hidden="true" />;
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d={preset.icon.path} />
+    </svg>
+  );
+}

--- a/apps/web/tests/features/profile/schemas.test.ts
+++ b/apps/web/tests/features/profile/schemas.test.ts
@@ -22,6 +22,16 @@ describe("social link handle/URL round-trip", () => {
     expect(links).toEqual({ instagram: "https://instagram.com/foo.bar" });
   });
 
+  test("preset URLs with deeper paths are preserved", () => {
+    const links = roundTrip({ github: "https://github.com/owner/repository" });
+    expect(links).toEqual({ github: "https://github.com/owner/repository" });
+  });
+
+  test("preset URLs with trailing slashes are preserved", () => {
+    const links = roundTrip({ twitch: "https://twitch.tv/darsh/" });
+    expect(links).toEqual({ twitch: "https://twitch.tv/darsh/" });
+  });
+
   test("typed bare handle builds the full URL", () => {
     const form = createProfileFormValues(profileWith(null));
     form.socialLinks = [{ platform: "x", url: "darsh" }];

--- a/apps/web/tests/features/profile/schemas.test.ts
+++ b/apps/web/tests/features/profile/schemas.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+
+import type { UserOverview } from "@tsuki/api/types";
+
+import { createProfileFormValues, createProfileUpdate } from "@/features/profile/schemas";
+
+type Profile = UserOverview["profile"];
+
+function profileWith(socialLinks: Record<string, string> | null): Profile {
+  return { socialLinks } as Profile;
+}
+
+function roundTrip(links: Record<string, string> | null): Record<string, string> | null {
+  const original = createProfileFormValues(profileWith(links));
+  const update = createProfileUpdate(original, original);
+  return update.socialLinks ?? null;
+}
+
+describe("social link handle/URL round-trip", () => {
+  test("preset handles with dots survive save (instagram)", () => {
+    const links = roundTrip({ instagram: "https://instagram.com/foo.bar" });
+    expect(links).toEqual({ instagram: "https://instagram.com/foo.bar" });
+  });
+
+  test("typed bare handle builds the full URL", () => {
+    const form = createProfileFormValues(profileWith(null));
+    form.socialLinks = [{ platform: "x", url: "darsh" }];
+    const update = createProfileUpdate(form, form);
+    expect(update.socialLinks).toEqual({ x: "https://x.com/darsh" });
+  });
+
+  test("strips leading @ and keeps youtube handle format", () => {
+    const form = createProfileFormValues(profileWith(null));
+    form.socialLinks = [{ platform: "youtube", url: "@darsh" }];
+    const update = createProfileUpdate(form, form);
+    expect(update.socialLinks).toEqual({ youtube: "https://youtube.com/@darsh" });
+  });
+
+  test("domain with path is scheme-prefixed, not prefixed into the template", () => {
+    const form = createProfileFormValues(profileWith(null));
+    form.socialLinks = [{ platform: "x", url: "x.com/darsh" }];
+    const update = createProfileUpdate(form, form);
+    expect(update.socialLinks).toEqual({ x: "https://x.com/darsh" });
+  });
+
+  test("website links without a scheme get https://", () => {
+    const form = createProfileFormValues(profileWith(null));
+    form.socialLinks = [{ platform: "website", url: "d1rshan.me" }];
+    const update = createProfileUpdate(form, form);
+    expect(update.socialLinks).toEqual({ website: "https://d1rshan.me" });
+  });
+
+  test("existing full URLs are preserved", () => {
+    const links = roundTrip({
+      github: "https://github.com/darsh",
+      website: "https://d1rshan.me",
+    });
+    expect(links).toEqual({ github: "https://github.com/darsh", website: "https://d1rshan.me" });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "react-dom": "19.2.4",
         "recharts": "3.8.0",
         "shadcn": "^4.11.0",
+        "simple-icons": "^16.29.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
@@ -1822,6 +1823,8 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-icons": ["simple-icons@16.29.0", "", {}, "sha512-4H94f5ZgcCcgJroc902TFlFdgPu2IU2eD7+WebN2Z14xKYrKHeJ4UQcZwzgSuH4Rgzw+jp7sbHl40NefuIEYsg=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 


### PR DESCRIPTION
- Replace inline expand controls for avatar/banner with a pencil button that opens a dropdown (Upload / Remove); avatar edit now lives in the edit profile dialog
- Social links: preset platforms as brand icon buttons plus a dashed add-custom button; presets only need a username (URL built on submit), custom links take any URL with https:// auto-prefixed
- Bio card renders brand icons via shared social-presets module
- Clearing bio now stores as null (API accepts explicit null)
- Remove image-ownership state from banner/avatar/layout components; avatar image threaded to the dialog instead