### PR TITLE
chore(web): migrate to tanstack table v9

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "@giphy/react-components": "^10.1.2",
     "@tanstack/react-form": "^1.33.5",
     "@tanstack/react-query": "^5.101.0",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.2.4",
     "@tiptap/react": "^3.30.3",
     "@tsuki/anilist": "workspace:*",
     "@tsuki/api": "workspace:*",

--- a/apps/web/src/features/admin/components/admin-user-columns.tsx
+++ b/apps/web/src/features/admin/components/admin-user-columns.tsx
@@ -21,6 +21,7 @@ import { authClient } from "@tsuki/auth/client";
 import { Avatar, AvatarFallback, AvatarImage } from "@/shared/components/ui/avatar";
 import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
+import type { DataTableFeatures } from "@/shared/components/ui/data-table";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,7 +37,7 @@ import type { AdminUser } from "../types";
 
 type AdminAction = () => Promise<{ error: { message?: string | null } | null }>;
 
-export const adminUserColumns: ColumnDef<AdminUser>[] = [
+export const adminUserColumns: ColumnDef<DataTableFeatures, AdminUser>[] = [
   {
     accessorKey: "displayUsername",
     header: "User",

--- a/apps/web/src/shared/components/ui/data-table.tsx
+++ b/apps/web/src/shared/components/ui/data-table.tsx
@@ -4,15 +4,20 @@ import * as React from "react";
 import type {
   ColumnDef,
   ColumnFiltersState,
+  ColumnVisibilityState,
   PaginationState,
-  VisibilityState,
+  RowData,
 } from "@tanstack/react-table";
 import {
+  columnFilteringFeature,
+  columnVisibilityFeature,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  filterFn_includesString,
   flexRender,
-  getCoreRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  useReactTable,
+  rowPaginationFeature,
+  tableFeatures,
+  useTable,
 } from "@tanstack/react-table";
 import { ChevronDown } from "lucide-react";
 
@@ -34,8 +39,20 @@ import {
 } from "@/shared/components/ui/dropdown-menu";
 import { cn } from "@/shared/lib/utils";
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
+const dataTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  columnVisibilityFeature,
+  rowPaginationFeature,
+  filteredRowModel: createFilteredRowModel(),
+  paginatedRowModel: createPaginatedRowModel(),
+  // ponytail: only the default string filter is used (search input), register just that one
+  filterFns: { includesString: filterFn_includesString },
+});
+
+export type DataTableFeatures = typeof dataTableFeatures;
+
+interface DataTableProps<TData extends RowData> {
+  columns: ColumnDef<DataTableFeatures, TData, unknown>[];
   data: TData[];
   searchKey?: string;
   searchPlaceholder?: string;
@@ -48,7 +65,7 @@ interface DataTableProps<TData, TValue> {
   isDataPending?: boolean;
 }
 
-export function DataTable<TData, TValue>({
+export function DataTable<TData extends RowData>({
   columns,
   data,
   searchKey = "email",
@@ -60,24 +77,21 @@ export function DataTable<TData, TValue>({
   onPaginationChange,
   manualPagination,
   isDataPending = false,
-}: DataTableProps<TData, TValue>) {
+}: DataTableProps<TData>) {
   "use no memo";
 
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [columnVisibility, setColumnVisibility] = React.useState<ColumnVisibilityState>({});
 
-  // TanStack Table returns mutable functions that React Compiler must not memoize.
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
+  // Keep React Compiler memoization off for this table, same as before the v9 migration.
+  const table = useTable({
+    features: dataTableFeatures,
     data,
     columns,
     pageCount,
     manualPagination,
     onPaginationChange,
-    getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
     onColumnFiltersChange: setColumnFilters,
-    getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     state: {
       columnFilters,
@@ -157,7 +171,7 @@ export function DataTable<TData, TValue>({
             <TableBody>
               {table.getRowModel().rows?.length ? (
                 table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  <TableRow key={row.id}>
                     {row.getVisibleCells().map((cell) => (
                       <TableCell key={cell.id}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -178,7 +192,7 @@ export function DataTable<TData, TValue>({
         <div className="flex items-center justify-end space-x-2 py-4">
           <div className="flex-1 text-sm text-muted-foreground">
             {manualPagination
-              ? `Page ${table.getState().pagination.pageIndex + 1}`
+              ? `Page ${table.state.pagination.pageIndex + 1}`
               : `Showing ${table.getRowModel().rows.length} of ${table.getFilteredRowModel().rows.length} row(s).`}
           </div>
           <div className="space-x-2">

--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
         "@giphy/react-components": "^10.1.2",
         "@tanstack/react-form": "^1.33.5",
         "@tanstack/react-query": "^5.101.0",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "^9.2.4",
         "@tiptap/react": "^3.30.3",
         "@tsuki/anilist": "workspace:*",
         "@tsuki/api": "workspace:*",
@@ -652,11 +652,11 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.2.4", "", { "dependencies": { "@tanstack/react-store": "^0.11.1", "@tanstack/table-core": "9.2.4" }, "peerDependencies": { "react": ">=18" } }, "sha512-Rzp1Q4e0/nIgEjmISYR5HeEgLTNtrG+C7NFZf/AbCxPO5hg+zC3yNGwcoECigUk8SFzzvhXbd2rFdtP2ZiGrfA=="],
 
     "@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/table-core": ["@tanstack/table-core@9.2.4", "", { "dependencies": { "@tanstack/store": "^0.11.1" } }, "sha512-GwdDyGGr6UXAtubF14yAwcXvdaogqfsQgIk89Suebjxob/Rjq2xvfmXsjDF1rQmKmhHsJm9TOY7myxv3i6geJw=="],
 
     "@tiptap/core": ["@tiptap/core@3.31.2", "", { "peerDependencies": { "@tiptap/pm": "3.31.2" } }, "sha512-TB+8pLk1k+fCpuPQ6vGNNhSRlvIiOks79oWGykCVut2nbRpQ8GsORP9VK6Eahj2fzdQA96UQMIcK7AxoOZG/2w=="],
 


### PR DESCRIPTION
Supersedes #67.

Bumps @tanstack/react-table 8.21.3 -> 9.2.4 with the v9 API migration:

- useReactTable -> useTable with explicit tableFeatures (columnFiltering, columnVisibility, rowPagination + filtered/paginated row models)
- VisibilityState -> ColumnVisibilityState, table.getState() -> table.state
- ColumnDef types gain the TFeatures param via DataTableFeatures
- Registers only filterFn_includesString (only filter the search input needs)
- Drops dead row.getIsSelected() styling (no selection feature in use)